### PR TITLE
deploy: reorganize deploy resources, samples and solutions when deplo…

### DIFF
--- a/deploy/hwameistor.yaml
+++ b/deploy/hwameistor.yaml
@@ -1,0 +1,2112 @@
+---
+# Config: namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hwameistor-system
+
+---
+# Component: hwameistor/local-storage
+# Source: hwameistor/templates/local-storage.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hwameistor-local-storage 
+  namespace: hwameistor-system
+spec:
+  selector:
+    matchLabels:
+      app: hwameistor-local-storage 
+  template:
+    metadata:
+      labels:
+        app: hwameistor-local-storage 
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: lvm.hwameistor.io/enable
+                operator: Exists
+      containers:
+      - args:
+        - --v=5
+        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/lvm.hwameistor.io/csi.sock
+        env:
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/lvm.hwameistor.io /registration/lvm.hwameistor.io-reg.sock
+        name: registrar
+        resources: 
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - --nodename=$(MY_NODENAME)
+        - --namespace=$(POD_NAMESPACE)
+        - --csi-address=$(CSI_ENDPOINT)
+        - --http-port=80
+        - --debug=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: MY_NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CSI_ENDPOINT
+          value: unix://var/lib/kubelet/plugins/lvm.hwameistor.io/csi.sock
+        - name: NODE_ANNOTATION_KEY_STORAGE_IPV4
+          value: localstorage.hwameistor.io/storage-ipv4
+        image: ghcr.io/hwameistor/local-storage:v0.1.11
+        imagePullPolicy: IfNotPresent
+        name: member
+        ports:
+        - containerPort: 80
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          #  allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/plugins
+          mountPropagation: Bidirectional
+          name: plugin-dir
+        - mountPath: /var/lib/kubelet/plugins_registry
+          name: registration-dir
+        - mountPath: /var/lib/kubelet/pods
+          mountPropagation: Bidirectional
+          name: pods-mount-dir
+        - mountPath: /dev
+          name: host-dev
+        - mountPath: /etc/drbd.d
+          mountPropagation: Bidirectional
+          name: host-etc-drbd
+      dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      serviceAccountName: hwameistor-admin 
+      serviceAccount: hwameistor-admin
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/plugins/lvm.hwameistor.io
+          type: DirectoryOrCreate
+        name: socket-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins
+          type: DirectoryOrCreate
+        name: plugin-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+        name: registration-dir
+      - hostPath:
+          path: /dev
+          type: ""
+        name: host-dev
+      - hostPath:
+          path: /etc/drbd.d
+          type: DirectoryOrCreate
+        name: host-etc-drbd
+      - hostPath:
+          path: /var/lib/kubelet/pods
+          type: DirectoryOrCreate
+        name: pods-mount-dir
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+
+---
+# Component: hwameistor/local-disk-manager
+# Source: hwameistor/templates/local-disk-manager.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hwameistor-local-disk-manager
+  namespace: hwameistor-system
+spec:
+  selector:
+    matchLabels:
+      app: hwameistor-local-disk-manager
+  template:
+    metadata:
+      labels:
+        app: hwameistor-local-disk-manager
+    spec:
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: hwameistor-admin
+      containers:  
+        - name: registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/disk.hwameistor.io/csi.sock
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/bin/sh", "-c", "rm -rf /registration/disk.hwameistor.io  /registration/disk.hwameistor.io-reg.sock" ]
+          env:
+              - name: KUBE_NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: manager
+          # Replace this with the built image name
+          image: ghcr.io/hwameistor/local-disk-manager:v0.1.6
+          command:
+          - /local-disk-manager
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --nodeid=$(NODENAME)
+            - --csi-enable=true
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: udev
+            mountPath: /run/udev
+          - name: procmount
+            mountPath: /host/proc
+            readOnly: true
+          - name: devmount
+            mountPath: /dev
+          - name: registration-dir
+            mountPath: /var/lib/kubelet/plugins_registry
+          - name: plugin-dir
+            mountPath: /var/lib/kubelet/plugins
+            mountPropagation: "Bidirectional"
+          - name: pods-mount-dir
+            mountPath: /var/lib/kubelet/pods
+            mountPropagation: "Bidirectional"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix://var/lib/kubelet/plugins/disk.hwameistor.io/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPERATOR_NAME
+              value: "local-disk-manager"
+          securityContext:
+            privileged: true
+      volumes:
+      - name: udev
+        hostPath:
+          path: /run/udev
+          type: Directory
+      - name: procmount
+        # mount /proc/1/mounts (mount file of process 1 of host) inside container
+        # to read which partition is mounted on / path
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: devmount
+        # the /dev directory is mounted so that we have access to the devices that
+        # are connected at runtime of the pod.
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: socket-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/disk.hwameistor.io
+          type: DirectoryOrCreate
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet/pods
+          type: DirectoryOrCreate
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+
+---
+# Component: hwameistor/scheduler
+# Source: hwameistor/templates/scheduler.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hwameistor-scheduler
+  namespace: hwameistor-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hwameistor-scheduler
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: hwameistor-scheduler
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      containers:
+      - args:
+        - -v=2
+        - --bind-address=0.0.0.0
+        - --kubeconfig=/etc/kubernetes/scheduler.conf
+        - --leader-elect=false
+        - --leader-elect-resource-name=hwameistor-scheduler
+        - --leader-elect-resource-namespace=hwameistor-system
+        - --config=/etc/hwameistor/hwameistor-scheduler-config.yaml
+        image: ghcr.io/hwameistor/scheduler:v0.1.6-kube-pre1.20
+        imagePullPolicy: IfNotPresent
+        name: hwameistor-kube-scheduler
+        resources:
+          limits:
+            cpu: 300m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/kubernetes/scheduler.conf
+          name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/hwameistor/
+          name: hwameistor-scheduler-config
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/admin.conf
+          type: FileOrCreate
+        name: kubeconfig
+      - configMap:
+          name: hwameistor-scheduler-config 
+          items:
+          - key: hwameistor-scheduler-config.yaml
+            path: hwameistor-scheduler-config.yaml
+        name: hwameistor-scheduler-config
+      serviceAccountName: hwameistor-admin 
+      serviceAccount: hwameistor-admin
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+
+---
+# Component: hwameistor/local-disk-manager/csi/controller
+# Source: hwameistor/templates/local-disk-manager-csi-controller.yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hwameistor-local-disk-csi-controller
+  namespace: hwameistor-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hwameistor-local-disk-csi-controller
+  template:
+    metadata:
+      labels:
+        app: hwameistor-local-disk-csi-controller
+    spec:
+      priorityClassName: system-cluster-critical
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - hwameistor-local-disk-manager
+            topologyKey: topology.disk.hwameistor.io/node
+      serviceAccount: hwameistor-admin
+      containers:
+        - name: provisioner
+          image: quay.io/k8scsi/csi-provisioner:v2.0.3
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - "--v=5"
+            - "--csi-address=$(CSI_ADDRESS)"
+            - "--leader-election=true"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology"
+            - "--extra-create-metadata=true"
+          env:
+            - name: CSI_ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: attacher
+          image: quay.io/k8scsi/csi-attacher:v3.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(CSI_ADDRESS)"
+            - "--leader-election=true"
+            - "--timeout=120s"
+          env:
+            - name: CSI_ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/disk.hwameistor.io
+            type: DirectoryOrCreate
+
+---
+# Component: hwameistor/local-storage/csi/controller
+# Source: hwameistor/templates/local-storage-csi-controller.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hwameistor-local-storage-csi-controller 
+  namespace: hwameistor-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hwameistor-local-storage-csi-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: hwameistor-local-storage-csi-controller
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - hwameistor-local-storage
+            topologyKey: topology.lvm.hwameistor.io/node
+      containers:
+      - args:
+        - --v=5
+        - --csi-address=$(CSI_ADDRESS)
+        - --leader-election=true
+        - --feature-gates=Topology=true
+        - --strict-topology
+        - --extra-create-metadata=true
+        env:
+        - name: CSI_ADDRESS
+          value: /csi/csi.sock
+        image: quay.io/k8scsi/csi-provisioner:v2.0.3
+        imagePullPolicy: IfNotPresent
+        name: provisioner
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --v=5
+        - --csi-address=$(CSI_ADDRESS)
+        - --leader-election=true
+        - --timeout=120s
+        env:
+        - name: CSI_ADDRESS
+          value: /csi/csi.sock
+        image: quay.io/k8scsi/csi-attacher:v3.0.1
+        imagePullPolicy: IfNotPresent
+        name: attacher
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --v=5
+        - --csi-address=$(CSI_ADDRESS)
+        - --leader-election=true
+        env:
+        - name: CSI_ADDRESS
+          value: /csi/csi.sock
+        image: quay.io/k8scsi/csi-resizer:v1.0.1
+        imagePullPolicy: IfNotPresent
+        name: resizer
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      serviceAccountName: hwameistor-admin 
+      serviceAccount: hwameistor-admin
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/plugins/lvm.hwameistor.io
+          type: DirectoryOrCreate
+        name: socket-dir
+
+---
+# Config: scheduler-config
+# Source: hwameistor/templates/scheduler-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hwameistor-scheduler-config
+  namespace: hwameistor-system
+data:
+  hwameistor-scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1alpha1
+    kind: KubeSchedulerConfiguration
+    schedulerName: hwameistor-scheduler
+    leaderElection:
+      leaderElect: true
+      lockObjectName: hwameistor-scheduler
+      resourceLock: leases
+    plugins:
+      filter:
+        enabled:
+          - name: hwameistor-scheduler-plugin
+      reserve:
+        enabled:
+          - name: hwameistor-scheduler-plugin
+      unreserve:
+        enabled:
+          - name: hwameistor-scheduler-plugin
+
+---
+# Config: clusterrole
+# Source: hwameistor/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hwameistor-role
+rules:
+- apiGroups: ["*"]
+  resources:
+  - "*"
+  verbs: ["*"]
+- nonResourceURLs: ["*"]
+  verbs: ["*"]
+
+---
+# Config: clusterrolebinding
+# Source: hwameistor/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hwameistor-admin-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hwameistor-role
+subjects:
+- kind: ServiceAccount
+  name: hwameistor-admin
+  namespace: hwameistor-system
+
+---
+# Config: serviceaccount
+# Source: hwameistor/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hwameistor-admin
+  namespace: hwameistor-system
+
+---
+# CustomResourceDefination: localstoragenode
+# Source: hwameistor/crds/hwameistor.io_localstoragenodes_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localdisknodes.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalDiskNode
+    listKind: LocalDiskNodeList
+    plural: localdisknodes
+    shortNames:
+    - ldn
+    singular: localdisknode
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.totalDisk
+      name: TotalDisk
+      type: integer
+    - jsonPath: .status.allocatableDisk
+      name: FreeDisk
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalDiskNode is the Schema for the localdisknodes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalDiskNodeSpec defines the desired state of LocalDiskNode
+            properties:
+              attachNode:
+                description: AttachNode represent where disk is attached
+                type: string
+            required:
+            - attachNode
+            type: object
+          status:
+            description: LocalDiskNodeStatus defines the observed state of LocalDiskNode
+            properties:
+              allocatableDisk:
+                description: AllocatableDisk
+                format: int64
+                type: integer
+              disks:
+                additionalProperties:
+                  properties:
+                    capacity:
+                      description: Capacity
+                      format: int64
+                      type: integer
+                    devPath:
+                      description: DevPath
+                      type: string
+                    diskType:
+                      description: DiskType SSD/HDD/NVME...
+                      type: string
+                    status:
+                      description: Status
+                      type: string
+                  required:
+                  - devPath
+                  - diskType
+                  - status
+                  type: object
+                description: Disks key is the name of LocalDisk
+                type: object
+              totalDisk:
+                description: TotalDisk
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+
+---
+# CustomResourceDefination: localvolume
+# Source: hwameistor/crds/hwameistor.io_localvolumes_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumes.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalVolume
+    listKind: LocalVolumeList
+    plural: localvolumes
+    shortNames:
+    - lv
+    singular: localvolume
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of storage pool
+      jsonPath: .spec.poolName
+      name: pool
+      type: string
+    - description: Number of volume replica
+      jsonPath: .spec.replicaNumber
+      name: replicas
+      type: integer
+    - description: Required capacity of the volume
+      jsonPath: .spec.requiredCapacityBytes
+      name: capacity
+      type: integer
+    - description: Accessibility of volume
+      jsonPath: .spec.accessibility.node
+      name: accessibility
+      type: string
+    - description: State of the volume
+      jsonPath: .status.state
+      name: state
+      type: string
+    - description: Allocated resource ID for the volume
+      jsonPath: .spec.config.resourceID
+      name: resource
+      type: integer
+    - description: Name of the node where the volume is in-use
+      jsonPath: .status.publishedNode
+      name: published
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalVolume is the Schema for the volumes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalVolumeSpec defines the desired state of LocalVolume
+            properties:
+              accessibility:
+                description: Accessibility is the topology requirement of the volume.
+                  It describes how to locate and distribute the volume replicas
+                properties:
+                  nodes:
+                    description: Nodes is the collection of storage nodes the volume
+                      replicas must locate at
+                    items:
+                      type: string
+                    type: array
+                  regions:
+                    default:
+                    - default
+                    description: regions where the volume replicas should be distributed
+                      across, it's Optional
+                    items:
+                      type: string
+                    type: array
+                  zones:
+                    default:
+                    - default
+                    description: zones where the volume replicas should be distributed
+                      across, it's Optional
+                    items:
+                      type: string
+                    type: array
+                type: object
+              config:
+                description: 'Config is the configration for the volume replicas It
+                  will be managed by the controller, and watched by all the nodes
+                  Important: node will manage volume replica according this config'
+                properties:
+                  convertible:
+                    description: Convertible is to indicate if the non-HA volume can
+                      be transitted to HA volume or not
+                    type: boolean
+                  initialized:
+                    type: boolean
+                  readyToInitialize:
+                    type: boolean
+                  replicas:
+                    items:
+                      description: VolumeReplica contains informations of replica
+                        peer
+                      properties:
+                        hostname:
+                          type: string
+                        id:
+                          type: integer
+                        ip:
+                          type: string
+                        primary:
+                          type: boolean
+                      required:
+                      - hostname
+                      - id
+                      - ip
+                      - primary
+                      type: object
+                    type: array
+                  requiredCapacityBytes:
+                    format: int64
+                    type: integer
+                  resourceID:
+                    description: ResourceID is for HA volume, set to '-1' for non-HA
+                      volume
+                    type: integer
+                  version:
+                    description: Version of config, start from 0, plus 1 every time
+                      config update
+                    type: integer
+                  volumeName:
+                    type: string
+                required:
+                - initialized
+                - readyToInitialize
+                - replicas
+                - resourceID
+                - version
+                - volumeName
+                type: object
+              convertible:
+                default: false
+                description: Convertible is to indicate if the non-HA volume can be
+                  transitted to HA volume or not
+                type: boolean
+              delete:
+                default: false
+                description: Delete is to indicate where the replica should be deleted
+                  or not. It's different from the regular resource delete interface
+                  in Kubernetes. The purpose is to protect it from any mistakes
+                type: boolean
+              poolName:
+                description: PoolName is the name of the storage pool, e.g. LocalStorage_PoolHDD,
+                  LocalStorage_PoolSSD, etc..
+                type: string
+              pvcName:
+                description: PersistentVolumeClaimName is the name of the associated
+                  PVC
+                type: string
+              pvcNamespace:
+                description: PersistentVolumeClaimNamespace is the namespace of the
+                  associated PVC
+                type: string
+              replicaNumber:
+                description: 'replica number: 1 - non-HA, 2 - HA, 3 - migration (temp)'
+                format: int64
+                maximum: 3
+                minimum: 1
+                type: integer
+              requiredCapacityBytes:
+                format: int64
+                minimum: 4194304
+                type: integer
+              volumegroup:
+                description: VolumeGroup is the group name of the local volumes. It
+                  is designed for the scheduling and allocating.
+                type: string
+            type: object
+          status:
+            description: LocalVolumeStatus defines the observed state of LocalVolume
+            properties:
+              allocatedCapacityBytes:
+                description: AllocatedCapacityBytes is the real allocated capacity
+                  in bytes of the volume replicas. In case of HA volume with multiple
+                  replicas, the value is equal to the one of a replica's size
+                format: int64
+                type: integer
+              publishedNode:
+                description: PublishedNodeName is the node where the volume is published
+                  and used by pod
+                type: string
+              replicas:
+                description: Volume is a logical concept and composed by one or many
+                  replicas which will be located at different node.
+                items:
+                  type: string
+                type: array
+              state:
+                description: State is the phase of volume replica, e.g. Creating,
+                  Ready, NotReady, ToBeDeleted, Deleted
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# CustomResourceDefination: localvolumecovert
+# Source: hwameistor/crds/hwameistor.io_localvolumeconverts_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumeconverts.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalVolumeConvert
+    listKind: LocalVolumeConvertList
+    plural: localvolumeconverts
+    shortNames:
+    - lvconvert
+    singular: localvolumeconvert
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the volume to convert
+      jsonPath: .spec.volumeName
+      name: volume
+      type: string
+    - description: Number of volume replica
+      jsonPath: .spec.replicaNumber
+      name: replicas
+      type: integer
+    - description: State of the expansion
+      jsonPath: .status.state
+      name: state
+      type: string
+    - description: Event message of the expansion
+      jsonPath: .status.message
+      name: message
+      type: string
+    - description: Abort the operation
+      jsonPath: .spec.abort
+      name: abort
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalVolumeConvert is the Schema for the localvolumeconverts
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalVolumeConvertSpec defines the desired state of LocalVolumeConvert
+            properties:
+              abort:
+                default: false
+                type: boolean
+              replicaNumber:
+                description: ReplicaNumber is the number of replicas which the volume
+                  will be converted to currently, only support the case of converting
+                  a non-HA volume to HA
+                format: int64
+                maximum: 2
+                minimum: 2
+                type: integer
+              volumeName:
+                type: string
+            type: object
+          status:
+            description: LocalVolumeConvertStatus defines the observed state of LocalVolumeConvert
+            properties:
+              message:
+                type: string
+              state:
+                description: State is state type of resources
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# CustomResourceDefination: localvolumeexpand
+# Source: hwameistor/crds/hwameistor.io_localvolumeexpands_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumeexpands.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalVolumeExpand
+    listKind: LocalVolumeExpandList
+    plural: localvolumeexpands
+    shortNames:
+    - lvexpand
+    singular: localvolumeexpand
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: New capacity of the volume
+      jsonPath: .spec.requiredCapacityBytes
+      name: newCapacity
+      type: integer
+    - description: Abort the operation
+      jsonPath: .spec.abort
+      name: abort
+      type: boolean
+    - description: State of the expansion
+      jsonPath: .status.state
+      name: state
+      type: string
+    - description: Sub-operations on each volume replica expansion
+      jsonPath: .status.subs
+      name: subs
+      type: string
+    - description: Event message of the expansion
+      jsonPath: .status.message
+      name: message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalVolumeExpand is the Schema for the localvolumeexpands API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalVolumeExpandSpec defines the desired state of LocalVolumeExpand
+            properties:
+              abort:
+                default: false
+                type: boolean
+              requiredCapacityBytes:
+                format: int64
+                minimum: 4194304
+                type: integer
+              volumeName:
+                type: string
+            type: object
+          status:
+            description: LocalVolumeExpandStatus defines the observed state of LocalVolumeExpand
+            properties:
+              allocatedCapacityBytes:
+                format: int64
+                type: integer
+              message:
+                type: string
+              state:
+                description: State is state type of resources
+                type: string
+              subs:
+                description: sub resources at different node.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# CustomResourceDefination: localvolumegroup
+# Source: hwameistor/crds/hwameistor.io_localvolumegroups_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumegroups.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalVolumeGroup
+    listKind: LocalVolumeGroupList
+    plural: localvolumegroups
+    shortNames:
+    - lvg
+    singular: localvolumegroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of associated pod
+      jsonPath: .spec.pods
+      name: pod
+      type: string
+    - description: Namespace of associated pod
+      jsonPath: .spec.namespace
+      name: namespace
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalVolumeGroup is the Schema for the localvolumegroups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalVolumeGroupSpec defines the desired state of LocalVolumeGroup
+            properties:
+              accessibility:
+                description: Accessibility is the topology requirement of the volume.
+                  It describes how to locate and distribute the volume replicas
+                properties:
+                  nodes:
+                    description: Nodes is the collection of storage nodes the volume
+                      replicas must locate at
+                    items:
+                      type: string
+                    type: array
+                  regions:
+                    default:
+                    - default
+                    description: regions where the volume replicas should be distributed
+                      across, it's Optional
+                    items:
+                      type: string
+                    type: array
+                  zones:
+                    default:
+                    - default
+                    description: zones where the volume replicas should be distributed
+                      across, it's Optional
+                    items:
+                      type: string
+                    type: array
+                type: object
+              pods:
+                items:
+                  type: string
+                type: array
+              volumes:
+                description: Volumes is the collection of the volumes in the group
+                items:
+                  properties:
+                    localvolume:
+                      description: LocalVolumeName is the name of the LocalVolume
+                      type: string
+                    pvc:
+                      description: PersistentVolumeClaimName is the name of the associated
+                        PVC
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: LocalVolumeGroupStatus defines the observed state of LocalVolumeGroup
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# CustomResourceDefination: localvolumemigrate
+# Source: hwameistor/crds/hwameistor.io_localvolumemigrates_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumemigrates.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalVolumeMigrate
+    listKind: LocalVolumeMigrateList
+    plural: localvolumemigrates
+    shortNames:
+    - lvmigrate
+    singular: localvolumemigrate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the volume to be migrated
+      jsonPath: .spec.volumeName
+      name: volume
+      type: string
+    - description: Node name of the volume replica to be migrated
+      jsonPath: .spec.nodeName
+      name: node
+      type: string
+    - description: Node name of the new volume replica
+      jsonPath: .status.targetNodeName
+      name: target
+      type: string
+    - description: State of the migration
+      jsonPath: .status.state
+      name: state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalVolumeMigrate is the Schema for the localvolumemigrates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalVolumeMigrateSpec defines the desired state of LocalVolumeMigrate
+            properties:
+              abort:
+                default: false
+                type: boolean
+              nodeName:
+                type: string
+              volumeName:
+                type: string
+            required:
+            - nodeName
+            - volumeName
+            type: object
+          status:
+            description: LocalVolumeMigrateStatus defines the observed state of LocalVolumeMigrate
+            properties:
+              message:
+                description: error message to describe some states
+                type: string
+              replicaNumber:
+                description: record the volume's replica number, it will be set internally
+                format: int64
+                type: integer
+              state:
+                description: State of the operation, e.g. submitted, started, completed,
+                  abort, ...
+                type: string
+              targetNodeName:
+                description: record the node where the specified replica is migrated
+                  to
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# CustomResourceDefination: localvolumereplica
+# Source: hwameistor/crds/hwameistor.io_localvolumereplicas_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumereplicas.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalVolumeReplica
+    listKind: LocalVolumeReplicaList
+    plural: localvolumereplicas
+    shortNames:
+    - lvr
+    singular: localvolumereplica
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Required capacity of the volume replica
+      jsonPath: .spec.requiredCapacityBytes
+      name: capacity
+      type: integer
+    - description: Node name where the volume replica is located at
+      jsonPath: .spec.nodeName
+      name: node
+      type: string
+    - description: State of the volume replica
+      jsonPath: .status.state
+      name: state
+      type: string
+    - description: Sync status of the volume replica
+      jsonPath: .status.synced
+      name: synced
+      type: boolean
+    - description: Device path of the volume replica
+      jsonPath: .status.devPath
+      name: device
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalVolumeReplica is the Schema for the volumereplicas API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalVolumeReplicaSpec defines the desired state of LocalVolumeReplica
+            properties:
+              delete:
+                default: false
+                description: Delete is to indicate where the replica should be deleted
+                  or not. It's different from the regular resource delete interface
+                  in Kubernetes. The purpose is to protect it from any mistakes
+                type: boolean
+              nodeName:
+                description: NodeName is the assigned node where the volume replica
+                  is located
+                type: string
+              poolName:
+                description: PoolName is the name of the storage pool, e.g. LocalStorage_PoolHDD,
+                  LocalStorage_PoolSSD, etc..
+                type: string
+              requiredCapacityBytes:
+                format: int64
+                minimum: 4194304
+                type: integer
+              volumeName:
+                description: VolumeName is the name of the volume, e.g. pvc-fbf3ffc3-66db-4dae-9032-bda3c61b8f85
+                type: string
+            type: object
+          status:
+            description: LocalVolumeReplicaStatus defines the observed state of LocalVolumeReplica
+            properties:
+              allocatedCapacityBytes:
+                description: AllocatedCapacityBytes is the real allocated capacity
+                  in bytes
+                format: int64
+                type: integer
+              devPath:
+                description: DevicePath is a link path of the StoragePath of the volume
+                  replica, e.g. /dev/LocalStorage_PoolHDD/pvc-fbf3ffc3-66db-4dae-9032-bda3c61b8f85
+                type: string
+              disks:
+                description: Disks is a list of physical disks where the volume replica
+                  is spread cross, especially for striped LVM volume replica
+                items:
+                  type: string
+                type: array
+              haState:
+                description: HAState is state for ha replica, replica.Status.State
+                  == Ready only when HAState is Consistent of nil
+                properties:
+                  reason:
+                    description: Reason is why this state happened
+                    type: string
+                  state:
+                    description: Consistent, Inconsistent, replica is ready only when
+                      consistent
+                    type: string
+                required:
+                - state
+                type: object
+              inuse:
+                default: false
+                description: InUse is one of volume replica's states, which indicates
+                  the replica is used by a Pod or not
+                type: boolean
+              state:
+                description: State is the phase of volume replica, e.g. Creating,
+                  Ready, NotReady, ToBeDeleted, Deleted
+                type: string
+              storagePath:
+                description: StoragePath is a real path of the volume replica, like
+                  /dev/sdg.
+                type: string
+              synced:
+                default: false
+                description: Synced is the sync state of the volume replica, which
+                  is important in HA volume
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# CustomResourceDefination: localdisk
+# Source: hwameistor/crds/hwameistor.io_localdisks_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localdisks.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalDisk
+    listKind: LocalDiskList
+    plural: localdisks
+    shortNames:
+    - ld
+    singular: localdisk
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.nodeName
+      name: NodeMatch
+      type: string
+    - jsonPath: .spec.claimRef.name
+      name: Claim
+      type: string
+    - jsonPath: .status.claimState
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalDisk is the Schema for the localdisks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalDiskSpec defines the desired state of LocalDisk
+            properties:
+              capacity:
+                description: Capacity of the disk in bytes
+                format: int64
+                type: integer
+              claimRef:
+                description: ClaimRef is the reference to the LDC which has claimed
+                  this LD
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              devicePath:
+                description: DevicePath is the disk path in the OS
+                type: string
+              diskAttributes:
+                description: DiskAttributes has hardware/static attributes of the
+                  disk
+                properties:
+                  devType:
+                    description: DeviceType represents the type of device like sparse,
+                      disk, partition, lvm, crypt
+                    type: string
+                  formFactor:
+                    description: FormFactor is the disk size, like 2.5 inches
+                    type: string
+                  modelName:
+                    description: ModelName is the name of disk model
+                    type: string
+                  pciVendorID:
+                    description: PCIVendorID is the ID of the PCI vendor, for NVMe
+                      disk only
+                    type: string
+                  product:
+                    description: Product is a class of disks the vendor produces
+                    type: string
+                  protocol:
+                    description: Protocol is for data transport, such as ATA, SCSI,
+                      NVMe
+                    type: string
+                  rotationRate:
+                    description: RotationRate is the rate of the disk rotation
+                    format: int64
+                    type: integer
+                  serialNumber:
+                    description: SerialNumber is a unique number assigned to a disk
+                    type: string
+                  type:
+                    description: Type is the disk type, such as ata, scsi, nvme, megaraid,N,
+                      ...
+                    type: string
+                  vendor:
+                    description: Vendor is who provides the disk
+                    type: string
+                type: object
+              isRaid:
+                description: HasRAID identifies if the disk is a raid disk or not
+                type: boolean
+              nodeName:
+                description: NodeName represents the node where the disk is attached
+                type: string
+              partitionInfo:
+                description: PartitionInfo contains partition information
+                items:
+                  description: PartitionInfo contains partition information(e.g. FileSystem)
+                  properties:
+                    filesystem:
+                      description: FileSystem contains mount point and filesystem
+                        type
+                      properties:
+                        fsType:
+                          description: Type represents the FileSystem type of the
+                            disk
+                          type: string
+                        mountPoint:
+                          description: MountPoint represents the mountpoint of the
+                            disk
+                          type: string
+                      type: object
+                    hasFileSystem:
+                      description: HasFileSystem represents whether the filesystem
+                        is included
+                      type: boolean
+                    path:
+                      description: Path represents the partition path in the OS
+                      type: string
+                  required:
+                  - hasFileSystem
+                  - path
+                  type: object
+                type: array
+              partitioned:
+                description: HasPartition represents if the disk has partitions or
+                  not
+                type: boolean
+              raidInfo:
+                description: RAIDInfo contains RAID information
+                properties:
+                  raidMaster:
+                    description: RAIDMaster is the master of the RAID disk, it works
+                      for only RAID slave disk, e.g. /dev/bus/0
+                    type: string
+                type: object
+              smartInfo:
+                description: SmartInfo contains infos collected by smartctl
+                properties:
+                  overallHealth:
+                    description: OverallHealth identifies if the disk is healthy or
+                      not
+                    type: string
+                required:
+                - overallHealth
+                type: object
+              state:
+                description: State is the current state of the disk (Active/Inactive/Unknown)
+                enum:
+                - Active
+                - Inactive
+                - Unknown
+                type: string
+              supportSmart:
+                description: HasSmartInfo identified if the disk supports SMART or
+                  not
+                type: boolean
+              uuid:
+                description: UUID global unique identifier of the disk
+                type: string
+            required:
+            - nodeName
+            type: object
+          status:
+            description: LocalDiskStatus defines the observed state of LocalDisk
+            properties:
+              claimState:
+                description: State represents the claim state of the disk
+                enum:
+                - Claimed
+                - Unclaimed
+                - Released
+                - Reserved
+                - Inuse
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+
+---
+# CustomResourceDefination: localdiskclaim
+# Source: hwameistor/crds/hwameistor.io_localdiskclaims_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localdiskclaims.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalDiskClaim
+    listKind: LocalDiskClaimList
+    plural: localdiskclaims
+    shortNames:
+    - ldc
+    singular: localdiskclaim
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.nodeName
+      name: NodeMatch
+      type: string
+    - jsonPath: .status.status
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalDiskClaim is the Schema for the localdiskclaims API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalDiskClaimSpec defines the desired state of LocalDiskClaim
+            properties:
+              description:
+                description: Description of the disk to be claimed
+                properties:
+                  capacity:
+                    description: Capacity of the disk in bytes
+                    format: int64
+                    type: integer
+                  diskType:
+                    description: DiskType represents the type of drive like SSD, HDD
+                      etc.,
+                    type: string
+                type: object
+              diskRefs:
+                description: DiskRefs represents which disks are assigned to the LocalDiskClaim
+                items:
+                  description: 'ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs.  1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage.  2.
+                    Invalid usage help.  It is impossible to add specific help for
+                    individual usage.  In most embedded usages, there are particular     restrictions
+                    like, "must refer only to types A and B" or "UID not honored"
+                    or "name must be restricted".     Those cannot be well described
+                    when embedded.  3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen.  4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity     during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple     and the version of the actual
+                    struct is irrelevant.  5. We cannot easily change it.  Because
+                    this type is embedded in many locations, updates to this type     will
+                    affect numerous schemas.  Don''t make new APIs embed an underspecified
+                    API type they do not control. Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              nodeName:
+                description: NodeName represents where disk has to be claimed.
+                type: string
+            required:
+            - nodeName
+            type: object
+          status:
+            description: LocalDiskClaimStatus defines the observed state of LocalDiskClaim
+            properties:
+              status:
+                description: Status represents the current statue of the claim
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+
+---
+# CustomResourceDefination: localdisknode
+# Source: hwameistor/crds/hwameistor.io_localdisknodes_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localdisknodes.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalDiskNode
+    listKind: LocalDiskNodeList
+    plural: localdisknodes
+    shortNames:
+    - ldn
+    singular: localdisknode
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.totalDisk
+      name: TotalDisk
+      type: integer
+    - jsonPath: .status.allocatableDisk
+      name: FreeDisk
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalDiskNode is the Schema for the localdisknodes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalDiskNodeSpec defines the desired state of LocalDiskNode
+            properties:
+              attachNode:
+                description: AttachNode represent where disk is attached
+                type: string
+            required:
+            - attachNode
+            type: object
+          status:
+            description: LocalDiskNodeStatus defines the observed state of LocalDiskNode
+            properties:
+              allocatableDisk:
+                description: AllocatableDisk
+                format: int64
+                type: integer
+              disks:
+                additionalProperties:
+                  properties:
+                    capacity:
+                      description: Capacity
+                      format: int64
+                      type: integer
+                    devPath:
+                      description: DevPath
+                      type: string
+                    diskType:
+                      description: DiskType SSD/HDD/NVME...
+                      type: string
+                    status:
+                      description: Status
+                      type: string
+                  required:
+                  - devPath
+                  - diskType
+                  - status
+                  type: object
+                description: Disks key is the name of LocalDisk
+                type: object
+              totalDisk:
+                description: TotalDisk
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+
+---
+# CustomResourceDefination: localdiskvolume
+# Source: hwameistor/crds/hwameistor.io_localdiskvolumes_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localdiskvolumes.hwameistor.io
+spec:
+  group: hwameistor.io
+  names:
+    kind: LocalDiskVolume
+    listKind: LocalDiskVolumeList
+    plural: localdiskvolumes
+    shortNames:
+    - ldv
+    singular: localdiskvolume
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.accessibility.node
+      name: Node
+      type: string
+    - jsonPath: .status.devPath
+      name: Disk
+      type: string
+    - jsonPath: .status.allocatedCapacityBytes
+      name: AllocatedCap
+      type: integer
+    - jsonPath: .spec.diskType
+      name: Type
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LocalDiskVolume is the Schema for the localdiskvolumes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalDiskVolumeSpec defines the desired state of LocalDiskVolume
+            properties:
+              accessibility:
+                description: Accessibility is the topology requirement of the volume.
+                  It describes how to locate and distribute the volume replicas
+                properties:
+                  node:
+                    description: One of the volume replica must be located at this
+                      node
+                    type: string
+                  regions:
+                    default:
+                    - default
+                    description: regions where the volume replicas should be distributed
+                      across, it's Optional
+                    items:
+                      type: string
+                    type: array
+                  zones:
+                    default:
+                    - default
+                    description: zones where the volume replicas should be distributed
+                      across, it's Optional
+                    items:
+                      type: string
+                    type: array
+                type: object
+              canWipe:
+                description: CanWipe represents if disk can wipe after Volume is deleted
+                  If disk has been writen data, this is will be changed to true
+                type: boolean
+              diskType:
+                description: DiskType represents the type of drive like SSD, HDD etc.,
+                type: string
+              persistentVolumeClaimName:
+                description: PersistentVolumeClaimName is the reference of the associated
+                  PVC
+                type: string
+              requiredCapacityBytes:
+                description: RequiredCapacityBytes
+                format: int64
+                type: integer
+            required:
+            - diskType
+            type: object
+          status:
+            description: LocalDiskVolumeStatus defines the observed state of LocalDiskVolume
+            properties:
+              allocatedCapacityBytes:
+                description: AllocatedCapacityBytes is the real allocated capacity
+                  in bytes
+                format: int64
+                type: integer
+              devPath:
+                description: DevPath is the disk path in the OS
+                type: string
+              localDiskName:
+                description: LocalDiskName is disk name which is used to create this
+                  volume
+                type: string
+              mountPoints:
+                description: MountPoints
+                items:
+                  description: MountPoint
+                  properties:
+                    fsTye:
+                      description: FsTye
+                      type: string
+                    mountOptions:
+                      description: MountOptions
+                      items:
+                        type: string
+                      type: array
+                    phase:
+                      description: Phase indicates the volume's next or current operation
+                      type: string
+                    targetPath:
+                      description: TargetPath
+                      type: string
+                    volumeCap:
+                      description: VolumeCap
+                      properties:
+                        accessMode:
+                          format: int32
+                          type: integer
+                        accessType:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              state:
+                description: State is the phase of volume replica, e.g. Creating,
+                  Ready, NotReady, ToBeDeleted, Deleted
+                type: string
+            required:
+            - devPath
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/deploy/samples/ioping-disk-fs.yaml
+++ b/deploy/samples/ioping-disk-fs.yaml
@@ -1,0 +1,46 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-disk-hdd-disk
+provisioner: disk.hwameistor.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+reclaimPolicy: Delete
+parameters:
+  diskType: "HDD"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: local-fs-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-disk-hdd-disk
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: local-fs-ioping
+spec:
+  schedulerName: hwameistor-scheduler
+  restartPolicy: Never
+  volumes:
+    - name: local-filesystem
+      persistentVolumeClaim:
+        claimName: local-fs-pvc
+  containers:
+    - name: perfrunner
+      image: hpestorage/ioping:latest
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash"]
+      args: ["-c", "while true ;do echo $(date) >> /data/time.log;sleep 5; done"]
+      volumeMounts:
+        - mountPath: /data
+          name: local-filesystem
+      tty: true

--- a/deploy/samples/ioping-disk.yaml
+++ b/deploy/samples/ioping-disk.yaml
@@ -1,0 +1,45 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-disk-hdd-disk
+provisioner: disk.hwameistor.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+reclaimPolicy: Delete
+parameters:
+  diskType: "HDD"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: local-disk-pvc
+spec:
+  volumeMode: Block
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-disk-hdd-disk
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: local-disk-ioping
+spec:
+  restartPolicy: Never
+  schedulerName: hwameistor-scheduler
+  volumes:
+    - name: local-disk
+      persistentVolumeClaim:
+        claimName: local-disk-pvc
+  containers:
+    - name: ioping
+      image: hpestorage/ioping:latest
+      command: [ "ioping" ]
+      args: [ "/dev/xsda" ]
+      volumeDevices:
+        - name: local-disk
+          devicePath: /dev/xsda

--- a/deploy/samples/nginx-lvm-ha.yaml
+++ b/deploy/samples/nginx-lvm-ha.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-local-storage-lvm-ha
+  labels:
+    app: nginx-local-storage-lvm-ha
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-local-storage-lvm-ha
+  template:
+    metadata:
+      labels:
+        app: nginx-local-storage-lvm-ha
+      name: nginx-local-storage-lvm-ha
+    spec:
+      schedulerName: hwameistor-scheduler
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      containers:
+        - image: nginx:latest
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 80
+          command:
+            - sh
+            - -xc
+            - |
+              VOL="$( df | grep /usr/share/nginx/html | awk '{print $1,$NF}' )"
+              echo "<center><h1>Demo volume: ${VOL}</h1></center>" > /usr/share/nginx/html/index.html
+              nginx -g "daemon off;"
+          volumeMounts:
+            - name: html-root
+              mountPath: /usr/share/nginx/html
+          resources:
+            limits:
+              cpu: '100m'
+              memory: '100Mi'
+      volumes:
+        - name: html-root
+          persistentVolumeClaim:
+            claimName: local-storage-pvc-lvm-ha
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: local-storage-pvc-lvm-ha
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage-hdd-lvm-ha
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage-hdd-lvm-ha
+provisioner: lvm.hwameistor.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  replicaNumber: "2"
+  poolClass: "HDD"
+  poolType: "REGULAR"
+  volumeKind: "LVM"
+  striped: "true"
+  csi.storage.k8s.io/fstype: "xfs"

--- a/deploy/samples/nginx-lvm-sts.yaml
+++ b/deploy/samples/nginx-lvm-sts.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-local-storage-lvm-svc
+  labels:
+    app: nginx-local-storage-lvm-sts
+spec:
+  ports:
+    - port: 80
+      name: web
+  clusterIP: None
+  selector:
+    app: nginx-local-storage-lvm-sts
+
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: nginx-local-storage-lvm-sts
+spec:
+  serviceName: "nginx"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx-local-storage-lvm-sts
+    spec:
+      schedulerName: hwameistor-scheduler
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+              name: web
+          volumeMounts:
+            - name: www
+              mountPath: /usr/share/nginx/html
+      volumes:
+        - name: www
+          persistentVolumeClaim:
+            claimName: local-storage-pvc-lvm
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: local-storage-pvc-lvm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage-hdd-lvm
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage-hdd-lvm
+provisioner: lvm.hwameistor.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  replicaNumber: "1"
+  poolClass: "HDD"
+  poolType: "REGULAR"
+  volumeKind: "LVM"
+  striped: "true"
+  csi.storage.k8s.io/fstype: "xfs"

--- a/deploy/samples/nginx-lvm.yaml
+++ b/deploy/samples/nginx-lvm.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-local-storage-lvm
+  labels:
+    app: nginx-local-storage-lvm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-local-storage-lvm
+  template:
+    metadata:
+      labels:
+        app: nginx-local-storage-lvm
+      name: nginx-local-storage-lvm
+    spec:
+      schedulerName: hwameistor-scheduler
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      containers:
+        - image: nginx:latest
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 80
+          command:
+            - sh
+            - -xc
+            - |
+              VOL="$( df | grep /usr/share/nginx/html | awk '{print $1,$NF}' )"
+              echo "<center><h1>Demo volume: ${VOL}</h1></center>" > /usr/share/nginx/html/index.html
+              nginx -g "daemon off;"
+          volumeMounts:
+            - name: html-root
+              mountPath: /usr/share/nginx/html
+          resources:
+            limits:
+              cpu: '100m'
+              memory: '100Mi'
+      volumes:
+        - name: html-root
+          persistentVolumeClaim:
+            claimName: local-storage-pvc-lvm
+      tolerations:
+        - key: "key-test"
+          value: "key-value"
+          operator: "Equal"
+          effect: "NoExecute"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: local-storage-pvc-lvm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage-hdd-lvm
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage-hdd-lvm
+provisioner: lvm.hwameistor.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  replicaNumber: "1"
+  poolClass: "HDD"
+  poolType: "REGULAR"
+  volumeKind: "LVM"
+  striped: "true"
+  csi.storage.k8s.io/fstype: "xfs"

--- a/deploy/samples/resources/localdiskclaim.yaml
+++ b/deploy/samples/resources/localdiskclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: hwameistor.io/v1alpha1
+kind: LocalDiskClaim
+metadata:
+  name: claim-k8s-node1-disks-sample
+  namespace: hwameistor
+spec:
+  # nodeName is the node where disk is attached
+  # If nodeName contains ".",please replace it with "-".
+  # The field value should be consistent with the nodeName in localdisk
+  nodeName: k8s-node1
+  description:
+    diskType: HDD

--- a/deploy/solutions/pulsar/pulsar.yaml
+++ b/deploy/solutions/pulsar/pulsar.yaml
@@ -1,0 +1,6063 @@
+---
+# Source: pulsar/templates/namespace.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pulsar
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/podsecuritypolicy.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: pulsar-loki
+  namespace: pulsar
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    heritage: Helm
+    release: pulsar
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/podsecuritypolicy.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: pulsar-promtail
+  namespace: pulsar
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    heritage: Helm
+    release: pulsar
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'secret'
+    - 'configMap'
+    - 'hostPath'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "pulsar-bookie"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: bookie
+spec:
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: bookie
+  maxUnavailable: 1
+---
+# Source: pulsar/templates/broker/broker-pdb.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "pulsar-broker"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: broker
+spec:
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: broker
+  maxUnavailable: 1
+---
+# Source: pulsar/templates/proxy/proxy-pdb.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "pulsar-proxy"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: proxy
+spec:
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: proxy
+  maxUnavailable: 1
+---
+# Source: pulsar/templates/zookeeper/zookeeper-pdb.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# deploy zookeeper only when `components.zookeeper` is true
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "pulsar-zookeeper"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: zookeeper
+spec:
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: zookeeper
+  maxUnavailable: 1
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    heritage: Helm
+    release: pulsar
+  annotations:
+    {}
+  name: pulsar-loki
+  namespace: pulsar
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    heritage: Helm
+    release: pulsar
+  name: pulsar-promtail
+  namespace: pulsar
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-service-account.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pulsar-bookie-acct
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: bookie
+  annotations:
+---
+# Source: pulsar/templates/broker/broker-service-account.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pulsar-broker-acct
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: broker
+  annotations:
+---
+# Source: pulsar/templates/prometheus/pulsar-operators-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pulsar-pulsar-operator
+  namespace: pulsar
+---
+# Source: pulsar/templates/proxy/proxy-service-account.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pulsar-proxy-acct
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: proxy
+  annotations:
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pulsar-loki
+  namespace: pulsar
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    release: pulsar
+    heritage: Helm
+data:
+  loki.yaml: YXV0aF9lbmFibGVkOiBmYWxzZQpjaHVua19zdG9yZV9jb25maWc6CiAgbWF4X2xvb2tfYmFja19wZXJpb2Q6IDAKaW5nZXN0ZXI6CiAgY2h1bmtfYmxvY2tfc2l6ZTogMjYyMTQ0CiAgY2h1bmtfaWRsZV9wZXJpb2Q6IDNtCiAgY2h1bmtfcmV0YWluX3BlcmlvZDogMW0KICBsaWZlY3ljbGVyOgogICAgcmluZzoKICAgICAga3ZzdG9yZToKICAgICAgICBzdG9yZTogaW5tZW1vcnkKICAgICAgcmVwbGljYXRpb25fZmFjdG9yOiAxCiAgbWF4X3RyYW5zZmVyX3JldHJpZXM6IDAKbGltaXRzX2NvbmZpZzoKICBlbmZvcmNlX21ldHJpY19uYW1lOiBmYWxzZQogIHJlamVjdF9vbGRfc2FtcGxlczogdHJ1ZQogIHJlamVjdF9vbGRfc2FtcGxlc19tYXhfYWdlOiAxNjhoCnNjaGVtYV9jb25maWc6CiAgY29uZmlnczoKICAtIGZyb206ICIyMDE4LTA0LTE1IgogICAgaW5kZXg6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGluZGV4XwogICAgb2JqZWN0X3N0b3JlOiBmaWxlc3lzdGVtCiAgICBzY2hlbWE6IHY5CiAgICBzdG9yZTogYm9sdGRiCnNlcnZlcjoKICBodHRwX2xpc3Rlbl9wb3J0OiAzMTAwCnN0b3JhZ2VfY29uZmlnOgogIGJvbHRkYjoKICAgIGRpcmVjdG9yeTogL2RhdGEvbG9raS9pbmRleAogIGZpbGVzeXN0ZW06CiAgICBkaXJlY3Rvcnk6IC9kYXRhL2xva2kvY2h1bmtzCnRhYmxlX21hbmFnZXI6CiAgcmV0ZW50aW9uX2RlbGV0ZXNfZW5hYmxlZDogZmFsc2UKICByZXRlbnRpb25fcGVyaW9kOiAwcw==
+---
+# Source: pulsar/templates/grafana/grafana-admin-secret.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "pulsar-grafana-secret"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: grafana
+type: Opaque
+stringData:
+  GRAFANA_ADMIN_PASSWORD: pulsar
+  GRAFANA_ADMIN_USER: pulsar
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pulsar-promtail
+  namespace: pulsar
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    release: pulsar
+    heritage: Helm
+data:
+  promtail.yaml: |
+    client:
+      backoff_config:
+        maxbackoff: 5s
+        maxretries: 20
+        minbackoff: 100ms
+      batchsize: 102400
+      batchwait: 1s
+      external_labels: {}
+      timeout: 10s
+    positions:
+      filename: /run/promtail/positions.yaml
+    server:
+      http_listen_port: 3101
+    target_config:
+      sync_period: 10s
+    scrape_configs:
+    - job_name: kubernetes-pods-name
+      pipeline_stages:
+        - docker: {}
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_name
+        target_label: __service__
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: ''
+        source_labels:
+        - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __service__
+        target_label: job
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_uid
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__
+    - job_name: kubernetes-pods-app
+      pipeline_stages:
+        - docker: {}
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: drop
+        regex: .+
+        source_labels:
+        - __meta_kubernetes_pod_label_name
+      - source_labels:
+        - __meta_kubernetes_pod_label_app
+        target_label: __service__
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: ''
+        source_labels:
+        - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __service__
+        target_label: job
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_uid
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__
+    - job_name: kubernetes-pods-direct-controllers
+      pipeline_stages:
+        - docker: {}
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: drop
+        regex: .+
+        separator: ''
+        source_labels:
+        - __meta_kubernetes_pod_label_name
+        - __meta_kubernetes_pod_label_app
+      - action: drop
+        regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
+        source_labels:
+        - __meta_kubernetes_pod_controller_name
+      - source_labels:
+        - __meta_kubernetes_pod_controller_name
+        target_label: __service__
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: ''
+        source_labels:
+        - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __service__
+        target_label: job
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_uid
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__
+    - job_name: kubernetes-pods-indirect-controller
+      pipeline_stages:
+        - docker: {}
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: drop
+        regex: .+
+        separator: ''
+        source_labels:
+        - __meta_kubernetes_pod_label_name
+        - __meta_kubernetes_pod_label_app
+      - action: keep
+        regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
+        source_labels:
+        - __meta_kubernetes_pod_controller_name
+      - action: replace
+        regex: '([0-9a-z-.]+)-[0-9a-f]{8,10}'
+        source_labels:
+        - __meta_kubernetes_pod_controller_name
+        target_label: __service__
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: ''
+        source_labels:
+        - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __service__
+        target_label: job
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_uid
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__
+    - job_name: kubernetes-pods-static
+      pipeline_stages:
+        - docker: {}
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: drop
+        regex: ''
+        source_labels:
+        - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_label_component
+        target_label: __service__
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: ''
+        source_labels:
+        - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __service__
+        target_label: job
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__
+---
+# Source: pulsar/charts/loki-stack/templates/datasources.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pulsar-loki-stack
+  namespace: pulsar
+  labels:
+    app: loki-stack
+    chart: loki-stack-0.36.1
+    release: pulsar
+    heritage: Helm
+    grafana_datasource: "1"
+data:
+  loki-stack-datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+    - name: Loki
+      type: loki
+      access: proxy
+      url: http://pulsar-loki:3100
+      version: 1
+---
+# Source: pulsar/charts/loki-stack/templates/tests/loki-test-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pulsar-loki-stack-test
+  labels:
+    app: loki-stack
+    chart: loki-stack-0.36.1
+    release: pulsar
+    heritage: Helm
+data:
+  test.sh: |
+    #!/usr/bin/env bash
+
+    LOKI_URI="http://${LOKI_SERVICE}:${LOKI_PORT}"
+
+    function setup() {
+      apk add -u curl jq
+      until (curl -s ${LOKI_URI}/api/prom/label/app/values | jq -e '.values[] | select(. == "loki")'); do
+        sleep 1
+      done
+    }
+
+    @test "Has labels" {
+      curl -s ${LOKI_URI}/api/prom/label | \
+      jq -e '.values[] | select(. == "app")'
+    }
+
+    @test "Query log entry" {
+      curl -sG ${LOKI_URI}/api/prom/query?limit=10 --data-urlencode 'query={app="loki"}' | \
+      jq -e '.streams[].entries | length >= 1'
+    }
+
+    @test "Push log entry legacy" {
+      local timestamp=$(date -Iseconds -u | sed 's/UTC/.000000000+00:00/')
+      local data=$(jq -n --arg timestamp "${timestamp}" '{"streams": [{"labels": "{app=\"loki-test\"}", "entries": [{"ts": $timestamp, "line": "foobar"}]}]}')
+
+      curl -s -X POST -H "Content-Type: application/json" ${LOKI_URI}/api/prom/push -d "${data}"
+
+      curl -sG ${LOKI_URI}/api/prom/query?limit=1 --data-urlencode 'query={app="loki-test"}' | \
+      jq -e '.streams[].entries[].line == "foobar"'
+    }
+
+    @test "Push log entry" {
+      local timestamp=$(date +%s000000000)
+      local data=$(jq -n --arg timestamp "${timestamp}" '{"streams": [{"stream": {"app": "loki-test"}, "values": [[$timestamp, "foobar"]]}]}')
+
+      curl -s -X POST -H "Content-Type: application/json" ${LOKI_URI}/loki/api/v1/push -d "${data}"
+
+      curl -sG ${LOKI_URI}/api/prom/query?limit=1 --data-urlencode 'query={app="loki-test"}' | \
+      jq -e '.streams[].entries[].line == "foobar"'
+    }
+---
+# Source: pulsar/templates/alert-manager/alertmanager-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-alert-manager"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: alert-manager
+data:
+  # For more configuration about the alert manager, please refer to https://prometheus.io/docs/alerting/configuration/
+  alertmanager.yml: |     
+    global:
+      resolve_timeout: 1m
+    receivers:
+    - name: pagerduty-notifications
+      pagerduty_configs:
+      - send_resolved: true
+        service_key: '[PAGER DUTRY SERVICE KEY]'
+    route:
+      group_interval: 1m
+      receiver: pagerduty-notifications
+      repeat_interval: 10m
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-autorecovery-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-recovery"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: recovery
+data:
+  # common config
+  zkServers: "pulsar-zookeeper:2181"
+  zkLedgersRootPath: "/ledgers"
+  # enable bookkeeper http server
+  httpServerEnabled: "true"
+  httpServerPort: "8000"
+  # config the stats provider
+  statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+  # use hostname as the bookie id
+  useHostNameAsBookieID: "true"
+  BOOKIE_MEM: |
+    -Xms64m -Xmx64m
+  log4j2.yaml: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    #
+  
+  
+    Configuration:
+      status: INFO
+      monitorInterval: 30
+      name: pulsar
+      packages: io.prometheus.client.log4j2
+  
+      Properties:
+        Property:
+          - name: "pulsar.log.dir"
+            value: "logs"
+          - name: "pulsar.log.file"
+            value: "pulsar.log"
+          - name: "pulsar.log.appender"
+            value: "RoutingAppender"
+          - name: "pulsar.log.root.level"
+            value: "info"
+          - name: "pulsar.log.level"
+            value: "info"
+          - name: "pulsar.routing.appender.default"
+            value: "Console"
+  
+      # Example: logger-filter script
+      Scripts:
+        ScriptFile:
+          name: filter.js
+          language: JavaScript
+          path: ./conf/log4j2-scripts/filter.js
+          charset: UTF-8
+  
+      Appenders:
+  
+        # Console
+        Console:
+          name: Console
+          target: SYSTEM_OUT
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+  
+        # Rolling file appender configuration
+        RollingFile:
+          name: RollingFile
+          fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
+          filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
+          immediateFlush: false
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+          Policies:
+            TimeBasedTriggeringPolicy:
+              interval: 1
+              modulate: true
+            SizeBasedTriggeringPolicy:
+              size: 1 GB
+          # Delete file older than 30days
+          DefaultRolloverStrategy:
+              Delete:
+                basePath: ${sys:pulsar.log.dir}
+                maxDepth: 2
+                IfFileName:
+                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                IfLastModified:
+                  age: 30d
+  
+        Prometheus:
+          name: Prometheus
+  
+        # Routing
+        Routing:
+          name: RoutingAppender
+          Routes:
+            pattern: "$${ctx:function}"
+            Route:
+              -
+                Routing:
+                  name: InstanceRoutingAppender
+                  Routes:
+                    pattern: "$${ctx:instance}"
+                    Route:
+                      -
+                        RollingFile:
+                          name: "Rolling-${ctx:function}"
+                          fileName : "${sys:pulsar.log.dir}/functions/${ctx:function}/${ctx:functionname}-${ctx:instance}.log"
+                          filePattern : "${sys:pulsar.log.dir}/functions/${sys:pulsar.log.file}-${ctx:instance}-%d{MM-dd-yyyy}-%i.log.gz"
+                          PatternLayout:
+                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                          Policies:
+                            TimeBasedTriggeringPolicy:
+                              interval: 1
+                              modulate: true
+                            SizeBasedTriggeringPolicy:
+                              size: "20MB"
+                            # Trigger every day at midnight that also scan
+                            # roll-over strategy that deletes older file
+                            CronTriggeringPolicy:
+                              schedule: "0 0 0 * * ?"
+                          # Delete file older than 30days
+                          DefaultRolloverStrategy:
+                              Delete:
+                                basePath: ${sys:pulsar.log.dir}
+                                maxDepth: 2
+                                IfFileName:
+                                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                                IfLastModified:
+                                  age: 30d
+                      - ref: "${sys:pulsar.routing.appender.default}"
+                        key: "${ctx:function}"
+              - ref: "${sys:pulsar.routing.appender.default}"
+                key: "${ctx:function}"
+  
+      Loggers:
+  
+        # Default root logger configuration
+        Root:
+          level: "${sys:pulsar.log.root.level}"
+          additivity: true
+          AppenderRef:
+            - ref: "${sys:pulsar.log.appender}"
+              level: "${sys:pulsar.log.level}"
+            - ref: Prometheus
+              level: info
+  
+        Logger:
+          - name: org.apache.bookkeeper.bookie.BookieShell
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+          - name: verbose
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+        # Logger to inject filter script
+    #     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
+    #       level: debug
+    #       additivity: false
+    #       AppenderRef:
+    #         ref: "${sys:pulsar.log.appender}"
+    #         ScriptFilter:
+    #           onMatch: ACCEPT
+    #           onMisMatch: DENY
+    #           ScriptRef:
+    #             ref: filter.js
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-bookie"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: bookie
+data:
+  # common config
+  zkServers: "pulsar-zookeeper:2181"
+  zkLedgersRootPath: "/ledgers"
+  # enable bookkeeper http server
+  httpServerEnabled: "true"
+  httpServerPort: "8000"
+  # config the stats provider
+  statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+  # use hostname as the bookie id
+  useHostNameAsBookieID: "true"
+  # disable auto recovery on bookies since we will start AutoRecovery in separated pods
+  autoRecoveryDaemonEnabled: "false"
+  # Do not retain journal files as it increase the disk utilization
+  journalMaxBackups: "0"
+  journalDirectories: "/pulsar/data/bookkeeper/journal"
+  PULSAR_PREFIX_journalDirectories: "/pulsar/data/bookkeeper/journal"
+  ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
+  # TLS config
+  
+  BOOKIE_MEM: |
+    -Xms128m -Xmx256m -XX:MaxDirectMemorySize=256m
+  PULSAR_GC: |
+    -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=4 -XX:ConcGCThreads=4 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintHeapAtGC -verbosegc -Xloggc:/var/log/bookie-gc.log -XX:G1LogLevel=finest
+  PULSAR_MEM: |
+    -Xms128m -Xmx256m -XX:MaxDirectMemorySize=256m
+  # Include log configuration file, If you want to configure the log level and other configuration
+  # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
+  log4j2.yaml: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    #
+  
+  
+    Configuration:
+      status: INFO
+      monitorInterval: 30
+      name: pulsar
+      packages: io.prometheus.client.log4j2
+  
+      Properties:
+        Property:
+          - name: "pulsar.log.dir"
+            value: "logs"
+          - name: "pulsar.log.file"
+            value: "pulsar.log"
+          - name: "pulsar.log.appender"
+            value: "RoutingAppender"
+          - name: "pulsar.log.root.level"
+            value: "info"
+          - name: "pulsar.log.level"
+            value: "info"
+          - name: "pulsar.routing.appender.default"
+            value: "Console"
+  
+      # Example: logger-filter script
+      Scripts:
+        ScriptFile:
+          name: filter.js
+          language: JavaScript
+          path: ./conf/log4j2-scripts/filter.js
+          charset: UTF-8
+  
+      Appenders:
+  
+        # Console
+        Console:
+          name: Console
+          target: SYSTEM_OUT
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+  
+        # Rolling file appender configuration
+        RollingFile:
+          name: RollingFile
+          fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
+          filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
+          immediateFlush: false
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+          Policies:
+            TimeBasedTriggeringPolicy:
+              interval: 1
+              modulate: true
+            SizeBasedTriggeringPolicy:
+              size: 1 GB
+          # Delete file older than 30days
+          DefaultRolloverStrategy:
+              Delete:
+                basePath: ${sys:pulsar.log.dir}
+                maxDepth: 2
+                IfFileName:
+                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                IfLastModified:
+                  age: 30d
+  
+        Prometheus:
+          name: Prometheus
+  
+        # Routing
+        Routing:
+          name: RoutingAppender
+          Routes:
+            pattern: "$${ctx:function}"
+            Route:
+              -
+                Routing:
+                  name: InstanceRoutingAppender
+                  Routes:
+                    pattern: "$${ctx:instance}"
+                    Route:
+                      -
+                        RollingFile:
+                          name: "Rolling-${ctx:function}"
+                          fileName : "${sys:pulsar.log.dir}/functions/${ctx:function}/${ctx:functionname}-${ctx:instance}.log"
+                          filePattern : "${sys:pulsar.log.dir}/functions/${sys:pulsar.log.file}-${ctx:instance}-%d{MM-dd-yyyy}-%i.log.gz"
+                          PatternLayout:
+                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                          Policies:
+                            TimeBasedTriggeringPolicy:
+                              interval: 1
+                              modulate: true
+                            SizeBasedTriggeringPolicy:
+                              size: "20MB"
+                            # Trigger every day at midnight that also scan
+                            # roll-over strategy that deletes older file
+                            CronTriggeringPolicy:
+                              schedule: "0 0 0 * * ?"
+                          # Delete file older than 30days
+                          DefaultRolloverStrategy:
+                              Delete:
+                                basePath: ${sys:pulsar.log.dir}
+                                maxDepth: 2
+                                IfFileName:
+                                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                                IfLastModified:
+                                  age: 30d
+                      - ref: "${sys:pulsar.routing.appender.default}"
+                        key: "${ctx:function}"
+              - ref: "${sys:pulsar.routing.appender.default}"
+                key: "${ctx:function}"
+  
+      Loggers:
+  
+        # Default root logger configuration
+        Root:
+          level: "${sys:pulsar.log.root.level}"
+          additivity: true
+          AppenderRef:
+            - ref: "${sys:pulsar.log.appender}"
+              level: "${sys:pulsar.log.level}"
+            - ref: Prometheus
+              level: info
+  
+        Logger:
+          - name: org.apache.bookkeeper.bookie.BookieShell
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+          - name: verbose
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+        # Logger to inject filter script
+    #     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
+    #       level: debug
+    #       additivity: false
+    #       AppenderRef:
+    #         ref: "${sys:pulsar.log.appender}"
+    #         ScriptFilter:
+    #           onMatch: ACCEPT
+    #           onMisMatch: DENY
+    #           ScriptRef:
+    #             ref: filter.js
+---
+# Source: pulsar/templates/broker/broker-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-broker"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: broker
+data:
+  # Metadata settings
+  zookeeperServers: "pulsar-zookeeper:2181"
+  configurationStoreServers: "pulsar-zookeeper:2181"
+
+  # Broker settings
+  clusterName: "pulsar"
+  exposeTopicLevelMetricsInPrometheus: "true"
+  numHttpServerThreads: "8"
+  zooKeeperSessionTimeoutMillis: "30000"
+  statusFilePath: "/pulsar/status"
+
+  ## Offloading settings
+
+  # Function Worker Settings
+  # function worker configuration
+  functionsWorkerEnabled: "true"
+
+  # prometheus needs to access /metrics endpoint
+  webServicePort: "8080"
+  brokerServicePort: "6650"
+
+  # Authentication Settings
+  AWS_ACCESS_KEY_ID: '[YOUR AWS ACCESS KEY ID]'
+  AWS_SECRET_ACCESS_KEY: '[YOUR SECRET]'
+  PULSAR_GC: |
+    -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=4 -XX:ConcGCThreads=4 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem
+  PULSAR_MEM: |
+    -Xms128m -Xmx256m -XX:MaxDirectMemorySize=256m
+  managedLedgerDefaultAckQuorum: "2"
+  managedLedgerDefaultEnsembleSize: "3"
+  managedLedgerDefaultWriteQuorum: "3"
+  # Include log configuration file, If you want to configure the log level and other configuration
+  # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
+  log4j2.yaml: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    #
+  
+  
+    Configuration:
+      status: INFO
+      monitorInterval: 30
+      name: pulsar
+      packages: io.prometheus.client.log4j2
+  
+      Properties:
+        Property:
+          - name: "pulsar.log.dir"
+            value: "logs"
+          - name: "pulsar.log.file"
+            value: "pulsar.log"
+          - name: "pulsar.log.appender"
+            value: "RoutingAppender"
+          - name: "pulsar.log.root.level"
+            value: "info"
+          - name: "pulsar.log.level"
+            value: "info"
+          - name: "pulsar.routing.appender.default"
+            value: "Console"
+  
+      # Example: logger-filter script
+      Scripts:
+        ScriptFile:
+          name: filter.js
+          language: JavaScript
+          path: ./conf/log4j2-scripts/filter.js
+          charset: UTF-8
+  
+      Appenders:
+  
+        # Console
+        Console:
+          name: Console
+          target: SYSTEM_OUT
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+  
+        # Rolling file appender configuration
+        RollingFile:
+          name: RollingFile
+          fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
+          filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
+          immediateFlush: false
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+          Policies:
+            TimeBasedTriggeringPolicy:
+              interval: 1
+              modulate: true
+            SizeBasedTriggeringPolicy:
+              size: 1 GB
+          # Delete file older than 30days
+          DefaultRolloverStrategy:
+              Delete:
+                basePath: ${sys:pulsar.log.dir}
+                maxDepth: 2
+                IfFileName:
+                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                IfLastModified:
+                  age: 30d
+  
+        Prometheus:
+          name: Prometheus
+  
+        # Routing
+        Routing:
+          name: RoutingAppender
+          Routes:
+            pattern: "$${ctx:function}"
+            Route:
+              -
+                Routing:
+                  name: InstanceRoutingAppender
+                  Routes:
+                    pattern: "$${ctx:instance}"
+                    Route:
+                      -
+                        RollingFile:
+                          name: "Rolling-${ctx:function}"
+                          fileName : "${sys:pulsar.log.dir}/functions/${ctx:function}/${ctx:functionname}-${ctx:instance}.log"
+                          filePattern : "${sys:pulsar.log.dir}/functions/${sys:pulsar.log.file}-${ctx:instance}-%d{MM-dd-yyyy}-%i.log.gz"
+                          PatternLayout:
+                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                          Policies:
+                            TimeBasedTriggeringPolicy:
+                              interval: 1
+                              modulate: true
+                            SizeBasedTriggeringPolicy:
+                              size: "20MB"
+                            # Trigger every day at midnight that also scan
+                            # roll-over strategy that deletes older file
+                            CronTriggeringPolicy:
+                              schedule: "0 0 0 * * ?"
+                          # Delete file older than 30days
+                          DefaultRolloverStrategy:
+                              Delete:
+                                basePath: ${sys:pulsar.log.dir}
+                                maxDepth: 2
+                                IfFileName:
+                                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                                IfLastModified:
+                                  age: 30d
+                      - ref: "${sys:pulsar.routing.appender.default}"
+                        key: "${ctx:function}"
+              - ref: "${sys:pulsar.routing.appender.default}"
+                key: "${ctx:function}"
+  
+      Loggers:
+  
+        # Default root logger configuration
+        Root:
+          level: "${sys:pulsar.log.root.level}"
+          additivity: true
+          AppenderRef:
+            - ref: "${sys:pulsar.log.appender}"
+              level: "${sys:pulsar.log.level}"
+            - ref: Prometheus
+              level: info
+  
+        Logger:
+          - name: org.apache.bookkeeper.bookie.BookieShell
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+          - name: verbose
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+        # Logger to inject filter script
+    #     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
+    #       level: debug
+    #       additivity: false
+    #       AppenderRef:
+    #         ref: "${sys:pulsar.log.appender}"
+    #         ScriptFilter:
+    #           onMatch: ACCEPT
+    #           onMisMatch: DENY
+    #           ScriptRef:
+    #             ref: filter.js
+---
+# Source: pulsar/templates/broker/function-worker-configfile-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+## function config map
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-functions-worker-configfile"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: functions-worker
+data:
+  functions_worker.yml: |
+    # Function package management
+    numFunctionPackageReplicas: 3
+    pulsarServiceUrl: pulsar://localhost:6650
+    pulsarWebServiceUrl: http://localhost:8080
+    pulsarFunctionsCluster: pulsar
+    functionRuntimeFactoryConfigs:
+      jobNamespace: pulsar
+      pulsarDockerImageName: "streamnative/pulsar-all:2.6.0-sn-21"
+      pulsarRootDir: /pulsar
+      pulsarAdminUrl: http://pulsar-broker.pulsar.svc.cluster.local:8080
+      pulsarServiceUrl: pulsar://pulsar-broker.pulsar.svc.cluster.local:6650 
+      changeConfigMap: "pulsar-functions-worker-config"
+      changeConfigMapNamespace: pulsar
+      submittingInsidePod: true
+      installUserCodeDependencies: true
+    # runtime customizer
+    assignmentWriteMaxRetries: 60
+    clusterCoordinationTopicName: coordinate
+    connectorsDirectory: ./connectors
+    downloadDirectory: download/pulsar_functions
+    failureCheckFreqMs: 30000
+    functionAssignmentTopicName: assignments
+    functionMetadataTopicName: metadata
+    functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+    functionsDirectory: ./functions
+    initialBrokerReconnectMaxRetries: 60
+    instanceLivenessCheckFreqMs: 30000
+    narExtractionDirectory: ""
+    numHttpServerThreads: 8
+    pulsarFunctionsNamespace: public/functions
+    rescheduleTimeoutMs: 60000
+    schedulerClassName: org.apache.pulsar.functions.worker.scheduler.RoundRobinScheduler
+    topicCompactionFrequencySec: 1800
+---
+# Source: pulsar/templates/broker/function-worker-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+## function config map
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-functions-worker-config"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: functions-worker
+data:
+  pulsarDockerImageName: "streamnative/pulsar-all:2.6.0-sn-21"
+---
+# Source: pulsar/templates/grafana/grafana-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-grafana"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: grafana
+data:
+  grafana.ini: "#\n# Copyright (c) 2018 Sijie. All Rights Reserved.\n#\n# Licensed under
+    the Apache License, Version 2.0 (the \"License\");\n# you may not use this file
+    except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#
+    \    http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable
+    law or agreed to in writing, software\n# distributed under the License is distributed
+    on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied.\n# See the License for the specific language governing permissions and\n#
+    limitations under the License.\n#\n\n##################### Grafana Configuration
+    Example #####################\n#\n# Everything has defaults so you only need to
+    uncomment things you want to\n# change\n\n# possible values : production, development\n;app_mode
+    = production\n\n# instance name, defaults to HOSTNAME environment variable value
+    or hostname if HOSTNAME var is empty\n;instance_name = ${HOSTNAME}\n\n####################################
+    Paths ####################################\n[paths]\n# Path to where grafana can
+    store temp files, sessions, and the sqlite3 db (if that is used)\ndata = /var/lib/grafana/pulsar/data\n\n#
+    Temporary files in `data` directory older than given duration will be removed\n;temp_data_lifetime
+    = 24h\n\n# Directory where grafana can store logs\n# logs = /var/lib/grafana/pulsar/logs\n\n#
+    Directory where grafana will automatically scan and look for plugins\nplugins =
+    /var/lib/grafana/pulsar/plugins\n\n# folder that contains provisioning config files
+    that grafana will apply on startup and while running.\nprovisioning = /var/lib/grafana/pulsar_provisioning\n\n####################################
+    Server ####################################\n[server]\n# Protocol (http, https,
+    socket)\n;protocol = http\n\n# The ip address to bind to, empty will bind to all
+    interfaces\n;http_addr =\n\n# The http port  to use\n# http_port = \n\n# The public
+    facing domain name used to access grafana from a browser\ndomain = {{ GRAFANA_DOMAIN
+    }}\nserve_from_sub_path = {{ GRAFANA_SERVE_FROM_SUB_PATH }}\n\n# Redirect to correct
+    domain if host header does not match domain\n# Prevents DNS rebinding attacks\n;enforce_domain
+    = false\n\n# The full public facing url you use in browser, used for redirects and
+    emails\n# If you use reverse proxy and sub path specify full url (with sub path)\nroot_url
+    = {{ GRAFANA_ROOT_URL }}\n\n# Log web requests\n;router_logging = false\n\n# the
+    path relative working path\n;static_root_path = public\n\n# enable gzip\n;enable_gzip
+    = false\n\n# https certs & key file\n;cert_file =\n;cert_key =\n\n# Unix socket
+    path\n;socket =\n\n#################################### Database ####################################\n[database]\n#
+    You can configure the database connection by specifying type, host, name, user and
+    password\n# as separate properties or as on string using the url properties.\n\n#
+    Either \"mysql\", \"postgres\" or \"sqlite3\", it's your choice\n;type = sqlite3\n;host
+    = 127.0.0.1:3306\n;name = grafana\n;user = root\n# If the password contains # or
+    ; you have to wrap it with triple quotes. Ex \"\"\"#password;\"\"\"\n;password =\n\n#
+    Use either URL or the previous fields to configure the database\n# Example: mysql://user:secret@host:port/database\n;url
+    =\n\n# For \"postgres\" only, either \"disable\", \"require\" or \"verify-full\"\n;ssl_mode
+    = disable\n\n# For \"sqlite3\" only, path relative to data_path setting\n;path =
+    grafana.db\n\n# Max idle conn setting default is 2\n;max_idle_conn = 2\n\n# Max
+    conn setting default is 0 (mean not set)\n;max_open_conn =\n\n# Connection Max Lifetime
+    default is 14400 (means 14400 seconds or 4 hours)\n;conn_max_lifetime = 14400\n\n#
+    Set to true to log the sql calls and execution times.\nlog_queries =\n\n####################################
+    Session ####################################\n[session]\n# Either \"memory\", \"file\",
+    \"redis\", \"mysql\", \"postgres\", default is \"file\"\n;provider = file\n\n# Provider
+    config options\n# memory: not have any config yet\n# file: session dir path, is
+    relative to grafana data_path\n# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`\n#
+    mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`\n#
+    postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable\n;provider_config
+    = sessions\n\n# Session cookie name\n;cookie_name = grafana_sess\n\n# If you use
+    session in https only, default is false\n;cookie_secure = false\n\n# Session life
+    time, default is 86400\n;session_life_time = 86400\n\n####################################
+    Data proxy ###########################\n[dataproxy]\n\n# This enables data proxy
+    logging, default is false\n;logging = false\n\n####################################
+    Analytics ####################################\n[analytics]\n# Server reporting,
+    sends usage counters to stats.grafana.org every 24 hours.\n# No ip addresses are
+    being tracked, only simple counters to track\n# running instances, dashboard and
+    error counts. It is very helpful to us.\n# Change this option to false to disable
+    reporting.\n;reporting_enabled = true\n\n# Set to false to disable all checks to
+    https://grafana.net\n# for new vesions (grafana itself and plugins), check is used\n#
+    in some UI views to notify that grafana or plugin update exists\n# This option does
+    not cause any auto updates, nor send any information\n# only a GET request to http://grafana.com
+    to get latest versions\ncheck_for_updates = true\n\n# Google Analytics universal
+    tracking code, only enabled if you specify an id here\n;google_analytics_ua_id =\n\n####################################
+    Security ####################################\n[security]\n# default admin user,
+    created on startup\nadmin_user = {{ GRAFANA_ADMIN_USER }}\n\n# default admin password,
+    can be changed before first start of grafana,  or in profile settings\nadmin_password
+    = {{ GRAFANA_ADMIN_PASSWORD }}\n\n# used for signing\n;secret_key = SW2YcwTIb9zpOOhoPsMm\n\n#
+    Auto-login remember days\n;login_remember_days = 7\n;cookie_username = grafana_user\n;cookie_remember_name
+    = grafana_remember\n\n# disable gravatar profile images\n;disable_gravatar = false\n\n#
+    data source proxy whitelist (ip_or_domain:port separated by spaces)\n;data_source_proxy_whitelist
+    =\n\n# disable protection against brute force login attempts\n;disable_brute_force_login_protection
+    = false\n\n#################################### Snapshots ###########################\n[snapshots]\n#
+    snapshot sharing options\n;external_enabled = true\n;external_snapshot_url = https://snapshots-origin.raintank.io\n;external_snapshot_name
+    = Publish to snapshot.raintank.io\n\n# remove expired snapshot\n;snapshot_remove_expired
+    = true\n\n#################################### Dashboards History ##################\n[dashboards]\n#
+    Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1\n;versions_to_keep
+    = 20\n\n#################################### Users ###############################\n[users]\n#
+    disable user signup / registration\n;allow_sign_up = true\n\n# Allow non admin users
+    to create organizations\n;allow_org_create = true\n\n# Set to true to automatically
+    assign new users to the default organization (id 1)\n;auto_assign_org = true\n\n#
+    Default role new users will be automatically assigned (if disabled above is set
+    to true)\n;auto_assign_org_role = Viewer\n\n# Background text for the user field
+    on the login page\n;login_hint = email or username\n\n# Default UI theme (\"dark\"
+    or \"light\")\n;default_theme = dark\n\n# External user management, these options
+    affect the organization users view\n;external_manage_link_url =\n;external_manage_link_name
+    =\n;external_manage_info =\n\n# Viewers can edit/inspect dashboard settings in the
+    browser. But not save the dashboard.\n;viewers_can_edit = false\n\n[auth]\n# Set
+    to true to disable (hide) the login form, useful if you use OAuth, defaults to false\n;disable_login_form
+    = false\n\n# Set to true to disable the signout link in the side menu. useful if
+    you use auth.proxy, defaults to false\n;disable_signout_menu = false\n\n# URL to
+    redirect the user to after sign out\n;signout_redirect_url =\n\n####################################
+    Anonymous Auth ##########################\n[auth.anonymous]\n# enable anonymous
+    access\n;enabled = false\n\n# specify organization name that should be used for
+    unauthenticated users\n;org_name = Main Org.\n\n# specify role for unauthenticated
+    users\n;org_role = Viewer\n\n#################################### Github Auth ##########################\n[auth.github]\n;enabled
+    = false\n;allow_sign_up = true\n;client_id = some_id\n;client_secret = some_secret\n;scopes
+    = user:email,read:org\n;auth_url = https://github.com/login/oauth/authorize\n;token_url
+    = https://github.com/login/oauth/access_token\n;api_url = https://api.github.com/user\n;team_ids
+    =\n;allowed_organizations =\n\n#################################### Google Auth
+    ##########################\n[auth.google]\n;enabled = false\n;allow_sign_up = true\n;client_id
+    = some_client_id\n;client_secret = some_client_secret\n;scopes = https://www.googleapis.com/auth/userinfo.profile
+    https://www.googleapis.com/auth/userinfo.email\n;auth_url = https://accounts.google.com/o/oauth2/auth\n;token_url
+    = https://accounts.google.com/o/oauth2/token\n;api_url = https://www.googleapis.com/oauth2/v1/userinfo\n;allowed_domains
+    =\n\n#################################### Generic OAuth ##########################\n[auth.generic_oauth]\n;enabled
+    = false\n;name = OAuth\n;allow_sign_up = true\n;client_id = some_id\n;client_secret
+    = some_secret\n;scopes = user:email,read:org\n;auth_url = https://foo.bar/login/oauth/authorize\n;token_url
+    = https://foo.bar/login/oauth/access_token\n;api_url = https://foo.bar/user\n;team_ids
+    =\n;allowed_organizations =\n;tls_skip_verify_insecure = false\n;tls_client_cert
+    =\n;tls_client_key =\n;tls_client_ca =\n\n#################################### Grafana.com
+    Auth ####################\n[auth.grafana_com]\n;enabled = false\n;allow_sign_up
+    = true\n;client_id = some_id\n;client_secret = some_secret\n;scopes = user:email\n;allowed_organizations
+    =\n\n#################################### Auth Proxy ##########################\n[auth.proxy]\n;enabled
+    = false\n;header_name = X-WEBAUTH-USER\n;header_property = username\n;auto_sign_up
+    = true\n;ldap_sync_ttl = 60\n;whitelist = 192.168.1.1, 192.168.2.1\n\n####################################
+    Basic Auth ##########################\n[auth.basic]\n;enabled = true\n\n####################################
+    Auth LDAP ##########################\n[auth.ldap]\n;enabled = false\n;config_file
+    = /etc/grafana/ldap.toml\n;allow_sign_up = true\n\n####################################
+    SMTP / Emailing ##########################\n[smtp]\n;enabled = false\n;host = localhost:25\n;user
+    =\n# If the password contains # or ; you have to wrap it with trippel quotes. Ex
+    \"\"\"#password;\"\"\"\n;password =\n;cert_file =\n;key_file =\n;skip_verify = false\n;from_address
+    = admin@grafana.localhost\n;from_name = Grafana\n# EHLO identity in SMTP dialog
+    (defaults to instance_name)\n;ehlo_identity = dashboard.example.com\n\n[emails]\n;welcome_email_on_sign_up
+    = false\n\n#################################### Logging ##########################\n[log]\n#
+    Either \"console\", \"file\", \"syslog\". Default is console and  file\n# Use space
+    to separate multiple modes, e.g. \"console file\"\nmode = console\n\n# Either \"debug\",
+    \"info\", \"warn\", \"error\", \"critical\", default is \"info\"\n;level = info\n\n#
+    optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug\n;filters
+    =\n\n# For \"console\" mode only\n[log.console]\n;level =\n\n# log line format,
+    valid options are text, console and json\n;format = console\n\n# For \"file\" mode
+    only\n[log.file]\nlevel = info\n\n# log line format, valid options are text, console
+    and json\nformat = text\n\n# This enables automated log rotate(switch of following
+    options), default is true\n;log_rotate = true\n\n# Max line number of single file,
+    default is 1000000\n;max_lines = 1000000\n\n# Max size shift of single file, default
+    is 28 means 1 << 28, 256MB\n;max_size_shift = 28\n\n# Segment log daily, default
+    is true\n;daily_rotate = true\n\n# Expired days of log file(delete after max days),
+    default is 7\n;max_days = 7\n\n[log.syslog]\n;level =\n\n# log line format, valid
+    options are text, console and json\n;format = text\n\n# Syslog network type and
+    address. This can be udp, tcp, or unix. If left blank, the default unix endpoints
+    will be used.\n;network =\n;address =\n\n# Syslog facility. user, daemon and local0
+    through local7 are valid.\n;facility =\n\n# Syslog tag. By default, the process'
+    argv[0] is used.\n;tag =\n\n#################################### Alerting ############################\n[alerting]\n#
+    Disable alerting engine & UI features\n;enabled = true\n# Makes it possible to turn
+    off alert rule execution but alerting UI is visible\n;execute_alerts = true\n\n#
+    Default setting for new alert rules. Defaults to categorize error and timeouts as
+    alerting. (alerting, keep_state)\n;error_or_timeout = alerting\n\n# Default setting
+    for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state,
+    ok)\n;nodata_or_nullvalues = no_data\n\n# Alert notifications can include images,
+    but rendering many images at the same time can overload the server\n# This limit
+    will protect the server from render overloading and make sure notifications are
+    sent out quickly\n;concurrent_render_limit = 5\n\n####################################
+    Explore #############################\n[explore]\n# Enable the Explore section\n;enabled
+    = false\n\n#################################### Internal Grafana Metrics ##########################\n#
+    Metrics available at HTTP API Url /metrics\n[metrics]\n# Disable / Enable internal
+    metrics\n;enabled           = true\n\n# Publish interval\n;interval_seconds  = 10\n\n#
+    Send internal metrics to Graphite\n[metrics.graphite]\n# Enable by setting the address
+    setting (ex localhost:2003)\n;address =\n;prefix = prod.grafana.%(instance_name)s.\n\n####################################
+    Distributed tracing ############\n[tracing.jaeger]\n# Enable by setting the address
+    sending traces to jaeger (ex localhost:6831)\n;address = localhost:6831\n# Tag that
+    will always be included in when creating new spans. ex (tag1:value1,tag2:value2)\n;always_included_tag
+    = tag1:value1\n# Type specifies the type of the sampler: const, probabilistic, rateLimiting,
+    or remote\n;sampler_type = const\n# jaeger samplerconfig param\n# for \"const\"
+    sampler, 0 or 1 for always false/true respectively\n# for \"probabilistic\" sampler,
+    a probability between 0 and 1\n# for \"rateLimiting\" sampler, the number of spans
+    per second\n# for \"remote\" sampler, param is the same as for \"probabilistic\"\n#
+    and indicates the initial sampling rate before the actual one\n# is received from
+    the mothership\n;sampler_param = 1\n\n#################################### Grafana.com
+    integration  ##########################\n# Url used to import dashboards directly
+    from Grafana.com\n[grafana_com]\nurl = https://grafana.com\n\n####################################
+    External image storage ##########################\n[external_image_storage]\n# Used
+    for uploading images to public servers so they can be included in slack/email messages.\n#
+    you can choose between (s3, webdav, gcs, azure_blob, local)\n;provider =\n\n[external_image_storage.s3]\n;bucket
+    =\n;region =\n;path =\n;access_key =\n;secret_key =\n\n[external_image_storage.webdav]\n;url
+    =\n;public_url =\n;username =\n;password =\n\n[external_image_storage.gcs]\n;key_file
+    =\n;bucket =\n;path =\n\n[external_image_storage.azure_blob]\n;account_name =\n;account_key
+    =\n;container_name =\n\n[external_image_storage.local]\n# does not require any configuration\n\n[rendering]\n#
+    Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer\n;server_url
+    =\n;callback_url =\n"
+---
+# Source: pulsar/templates/prometheus/prometheus-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-prometheus"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: prometheus
+data:
+  # Include prometheus configuration file, setup to monitor all the
+  # Kubernetes pods with the "scrape=true" annotation.
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    rule_files:
+      - 'rules.yml'
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets: ['pulsar-alert-manager:9093']
+        path_prefix: /
+    scrape_configs:
+    - job_name: 'prometheus'
+      static_configs:
+      - targets:
+        - '127.0.0.1:9090'
+      metrics_path: /metrics
+    - job_name: 'kubernetes-pods'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_label_component]
+        action: replace
+        target_label: job
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+    - job_name: 'kubernetes-nodes'
+      scheme: https
+      kubernetes_sd_configs:
+        - role: node
+
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics
+    - job_name: 'kubernetes-cadvisor'
+      scheme: https
+      kubernetes_sd_configs:
+        - role: node
+
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+  rules.yml: |
+    groups: null
+---
+# Source: pulsar/templates/proxy/proxy-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-proxy"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: proxy
+data:
+  clusterName: pulsar
+  httpNumThreads: "8"
+  statusFilePath: "/pulsar/status"
+  # prometheus needs to access /metrics endpoint
+  webServicePort: "8080"
+  servicePort: "6650"
+  brokerServiceURL: pulsar://pulsar-broker:6650 
+  brokerWebServiceURL: http://pulsar-broker:8080
+  brokerServiceURL: pulsar://pulsar-broker:6650 
+  brokerWebServiceURL: http://pulsar-broker:8080
+
+  # Authentication Settings
+  PULSAR_GC: |
+    -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=4 -XX:ConcGCThreads=4 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem
+  PULSAR_MEM: |
+    -Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m
+  # Include log configuration file, If you want to configure the log level and other configuration
+  # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
+  log4j2.yaml: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    #
+  
+  
+    Configuration:
+      status: INFO
+      monitorInterval: 30
+      name: pulsar
+      packages: io.prometheus.client.log4j2
+  
+      Properties:
+        Property:
+          - name: "pulsar.log.dir"
+            value: "logs"
+          - name: "pulsar.log.file"
+            value: "pulsar.log"
+          - name: "pulsar.log.appender"
+            value: "RoutingAppender"
+          - name: "pulsar.log.root.level"
+            value: "info"
+          - name: "pulsar.log.level"
+            value: "info"
+          - name: "pulsar.routing.appender.default"
+            value: "Console"
+  
+      # Example: logger-filter script
+      Scripts:
+        ScriptFile:
+          name: filter.js
+          language: JavaScript
+          path: ./conf/log4j2-scripts/filter.js
+          charset: UTF-8
+  
+      Appenders:
+  
+        # Console
+        Console:
+          name: Console
+          target: SYSTEM_OUT
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+  
+        # Rolling file appender configuration
+        RollingFile:
+          name: RollingFile
+          fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
+          filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
+          immediateFlush: false
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+          Policies:
+            TimeBasedTriggeringPolicy:
+              interval: 1
+              modulate: true
+            SizeBasedTriggeringPolicy:
+              size: 1 GB
+          # Delete file older than 30days
+          DefaultRolloverStrategy:
+              Delete:
+                basePath: ${sys:pulsar.log.dir}
+                maxDepth: 2
+                IfFileName:
+                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                IfLastModified:
+                  age: 30d
+  
+        Prometheus:
+          name: Prometheus
+  
+        # Routing
+        Routing:
+          name: RoutingAppender
+          Routes:
+            pattern: "$${ctx:function}"
+            Route:
+              -
+                Routing:
+                  name: InstanceRoutingAppender
+                  Routes:
+                    pattern: "$${ctx:instance}"
+                    Route:
+                      -
+                        RollingFile:
+                          name: "Rolling-${ctx:function}"
+                          fileName : "${sys:pulsar.log.dir}/functions/${ctx:function}/${ctx:functionname}-${ctx:instance}.log"
+                          filePattern : "${sys:pulsar.log.dir}/functions/${sys:pulsar.log.file}-${ctx:instance}-%d{MM-dd-yyyy}-%i.log.gz"
+                          PatternLayout:
+                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                          Policies:
+                            TimeBasedTriggeringPolicy:
+                              interval: 1
+                              modulate: true
+                            SizeBasedTriggeringPolicy:
+                              size: "20MB"
+                            # Trigger every day at midnight that also scan
+                            # roll-over strategy that deletes older file
+                            CronTriggeringPolicy:
+                              schedule: "0 0 0 * * ?"
+                          # Delete file older than 30days
+                          DefaultRolloverStrategy:
+                              Delete:
+                                basePath: ${sys:pulsar.log.dir}
+                                maxDepth: 2
+                                IfFileName:
+                                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                                IfLastModified:
+                                  age: 30d
+                      - ref: "${sys:pulsar.routing.appender.default}"
+                        key: "${ctx:function}"
+              - ref: "${sys:pulsar.routing.appender.default}"
+                key: "${ctx:function}"
+  
+      Loggers:
+  
+        # Default root logger configuration
+        Root:
+          level: "${sys:pulsar.log.root.level}"
+          additivity: true
+          AppenderRef:
+            - ref: "${sys:pulsar.log.appender}"
+              level: "${sys:pulsar.log.level}"
+            - ref: Prometheus
+              level: info
+  
+        Logger:
+          - name: org.apache.bookkeeper.bookie.BookieShell
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+          - name: verbose
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+        # Logger to inject filter script
+    #     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
+    #       level: debug
+    #       additivity: false
+    #       AppenderRef:
+    #         ref: "${sys:pulsar.log.appender}"
+    #         ScriptFilter:
+    #           onMatch: ACCEPT
+    #           onMisMatch: DENY
+    #           ScriptRef:
+    #             ref: filter.js
+---
+# Source: pulsar/templates/pulsar-manager/pulsar-manager-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-pulsar-manager-configmap"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: pulsar-manager
+data:
+  entrypoint.sh: |
+    apk add --update openssl && rm -rf /var/cache/apk/*;
+    mkdir conf;
+              
+    echo 'Starting PostGreSQL Server';
+    addgroup pulsar;
+    adduser --disabled-password --ingroup pulsar pulsar;
+    mkdir -p /run/postgresql;
+    chown -R pulsar:pulsar /run/postgresql/;
+    chown -R pulsar:pulsar /data;
+    chown pulsar:pulsar /pulsar-manager/init_db.sql;
+    chmod 750 /data;
+    su - pulsar -s /bin/sh /pulsar-manager/startup.sh;
+    echo 'Starting Pulsar Manager Front end';
+    nginx;
+    echo 'Starting Pulsar Manager Back end';
+    /pulsar-manager/pulsar-backend-entrypoint.sh;
+  backend_entrypoint.sh: |
+    /pulsar-manager/pulsar-manager/bin/pulsar-manager \
+      --spring.datasource.initialization-mode=never \
+      --spring.datasource.driver-class-name=org.postgresql.Driver \
+      --spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/pulsar_manager \
+      --spring.datasource.username=pulsar \
+      --spring.datasource.password=pulsar \
+      --pagehelper.helperDialect=postgresql \
+      --bookie.host="http://pulsar-bookie:8000" \
+      --bookie.enable=true \
+      --redirect.scheme=http \
+      --redirect.port=80 \
+      --redirect.host=admin.pulsar.test.pulsar.example.local \
+      --default.environment.name=pulsar \
+      --default.environment.service_url=http://pulsar-broker:8080 \
+      --tls.enabled=false \
+      --pulsar.peek.message=true
+---
+# Source: pulsar/templates/toolset/toolset-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-toolset"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: toolset
+data:
+  BOOKIE_LOG_APPENDER: "RollingFile"
+  zkServers: "pulsar-zookeeper:2181"
+  zkLedgersRootPath: "/ledgers"
+  # enable bookkeeper http server
+  httpServerEnabled: "true"
+  httpServerPort: "8000"
+  # config the stats provider
+  statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+  # use hostname as the bookie id
+  useHostNameAsBookieID: "true"
+  # talk to proxy
+  webServiceUrl: "http://pulsar-proxy:8080/"
+  brokerServiceUrl: "pulsar://pulsar-proxy:6650/"
+  # Authentication Settings 
+  PULSAR_MEM: |
+    -Xms64M -Xmx128M -XX:MaxDirectMemorySize=128M
+  # Include log configuration file, If you want to configure the log level and other configuration
+  # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
+  log4j2.yaml: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    #
+  
+  
+    Configuration:
+      status: INFO
+      monitorInterval: 30
+      name: pulsar
+      packages: io.prometheus.client.log4j2
+  
+      Properties:
+        Property:
+          - name: "pulsar.log.dir"
+            value: "logs"
+          - name: "pulsar.log.file"
+            value: "pulsar.log"
+          - name: "pulsar.log.appender"
+            value: "RoutingAppender"
+          - name: "pulsar.log.root.level"
+            value: "info"
+          - name: "pulsar.log.level"
+            value: "info"
+          - name: "pulsar.routing.appender.default"
+            value: "Console"
+  
+      # Example: logger-filter script
+      Scripts:
+        ScriptFile:
+          name: filter.js
+          language: JavaScript
+          path: ./conf/log4j2-scripts/filter.js
+          charset: UTF-8
+  
+      Appenders:
+  
+        # Console
+        Console:
+          name: Console
+          target: SYSTEM_OUT
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+  
+        # Rolling file appender configuration
+        RollingFile:
+          name: RollingFile
+          fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
+          filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
+          immediateFlush: false
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+          Policies:
+            TimeBasedTriggeringPolicy:
+              interval: 1
+              modulate: true
+            SizeBasedTriggeringPolicy:
+              size: 1 GB
+          # Delete file older than 30days
+          DefaultRolloverStrategy:
+              Delete:
+                basePath: ${sys:pulsar.log.dir}
+                maxDepth: 2
+                IfFileName:
+                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                IfLastModified:
+                  age: 30d
+  
+        Prometheus:
+          name: Prometheus
+  
+        # Routing
+        Routing:
+          name: RoutingAppender
+          Routes:
+            pattern: "$${ctx:function}"
+            Route:
+              -
+                Routing:
+                  name: InstanceRoutingAppender
+                  Routes:
+                    pattern: "$${ctx:instance}"
+                    Route:
+                      -
+                        RollingFile:
+                          name: "Rolling-${ctx:function}"
+                          fileName : "${sys:pulsar.log.dir}/functions/${ctx:function}/${ctx:functionname}-${ctx:instance}.log"
+                          filePattern : "${sys:pulsar.log.dir}/functions/${sys:pulsar.log.file}-${ctx:instance}-%d{MM-dd-yyyy}-%i.log.gz"
+                          PatternLayout:
+                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                          Policies:
+                            TimeBasedTriggeringPolicy:
+                              interval: 1
+                              modulate: true
+                            SizeBasedTriggeringPolicy:
+                              size: "20MB"
+                            # Trigger every day at midnight that also scan
+                            # roll-over strategy that deletes older file
+                            CronTriggeringPolicy:
+                              schedule: "0 0 0 * * ?"
+                          # Delete file older than 30days
+                          DefaultRolloverStrategy:
+                              Delete:
+                                basePath: ${sys:pulsar.log.dir}
+                                maxDepth: 2
+                                IfFileName:
+                                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                                IfLastModified:
+                                  age: 30d
+                      - ref: "${sys:pulsar.routing.appender.default}"
+                        key: "${ctx:function}"
+              - ref: "${sys:pulsar.routing.appender.default}"
+                key: "${ctx:function}"
+  
+      Loggers:
+  
+        # Default root logger configuration
+        Root:
+          level: "${sys:pulsar.log.root.level}"
+          additivity: true
+          AppenderRef:
+            - ref: "${sys:pulsar.log.appender}"
+              level: "${sys:pulsar.log.level}"
+            - ref: Prometheus
+              level: info
+  
+        Logger:
+          - name: org.apache.bookkeeper.bookie.BookieShell
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+          - name: verbose
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+        # Logger to inject filter script
+    #     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
+    #       level: debug
+    #       additivity: false
+    #       AppenderRef:
+    #         ref: "${sys:pulsar.log.appender}"
+    #         ScriptFilter:
+    #           onMatch: ACCEPT
+    #           onMisMatch: DENY
+    #           ScriptRef:
+    #             ref: filter.js
+  kafka.properties: |
+---
+# Source: pulsar/templates/zookeeper/gen-zk-conf.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-genzkconf-configmap"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+data:
+  gen-zk-conf.sh: |
+    #!/bin/bash
+    
+    # Apply env variables to config file and start the regular command
+    
+    CONF_FILE=$1
+    IDX=$2
+    PEER_TYPE=$3
+    
+    if [ $? != 0 ]; then
+        echo "Error: Failed to apply changes to config file"
+        exit 1
+    fi
+    
+    DOMAIN=`hostname -d`
+    
+    # Generate list of servers and detect the current server ID,
+    # based on the hostname
+    ((IDX++))
+    for SERVER in $(echo $ZOOKEEPER_SERVERS | tr "," "\n")
+    do
+        echo "server.$IDX=$SERVER.$DOMAIN:2888:3888:${PEER_TYPE};2181" >> $CONF_FILE
+    
+        if [ "$HOSTNAME" == "$SERVER" ]; then
+            MY_ID=$IDX
+            echo "Current server id $MY_ID"
+        fi
+    
+    	((IDX++))
+    done
+    
+    # For ZooKeeper container we need to initialize the ZK id
+    if [ ! -z "$MY_ID" ]; then
+        # Get ZK data dir
+        DATA_DIR=`grep '^dataDir=' $CONF_FILE | awk -F= '{print $2}'`
+        if [ ! -e $DATA_DIR/myid ]; then
+            echo "Creating $DATA_DIR/myid with id = $MY_ID"
+            mkdir -p $DATA_DIR
+            echo $MY_ID > $DATA_DIR/myid
+        fi
+    fi
+---
+# Source: pulsar/templates/zookeeper/zookeeper-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# deploy zookeeper only when `components.zookeeper` is true
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "pulsar-zookeeper"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: zookeeper
+data:
+  dataDir: /pulsar/data/zookeeper
+  PULSAR_PREFIX_serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
+  serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
+  # enable zookeeper tls
+  PULSAR_PREFIX_peerType: participant
+  PULSAR_GC: |
+    -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:+DisableExplicitGC -XX:+PerfDisableSharedMem -Dzookeeper.forceSync=no
+  PULSAR_MEM: |
+    -Xms64m -Xmx128m
+  # Include log configuration file, If you want to configure the log level and other configuration
+  # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
+  log4j2.yaml: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    #
+  
+  
+    Configuration:
+      status: INFO
+      monitorInterval: 30
+      name: pulsar
+      packages: io.prometheus.client.log4j2
+  
+      Properties:
+        Property:
+          - name: "pulsar.log.dir"
+            value: "logs"
+          - name: "pulsar.log.file"
+            value: "pulsar.log"
+          - name: "pulsar.log.appender"
+            value: "RoutingAppender"
+          - name: "pulsar.log.root.level"
+            value: "info"
+          - name: "pulsar.log.level"
+            value: "info"
+          - name: "pulsar.routing.appender.default"
+            value: "Console"
+  
+      # Example: logger-filter script
+      Scripts:
+        ScriptFile:
+          name: filter.js
+          language: JavaScript
+          path: ./conf/log4j2-scripts/filter.js
+          charset: UTF-8
+  
+      Appenders:
+  
+        # Console
+        Console:
+          name: Console
+          target: SYSTEM_OUT
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+  
+        # Rolling file appender configuration
+        RollingFile:
+          name: RollingFile
+          fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}"
+          filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
+          immediateFlush: false
+          PatternLayout:
+            Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+          Policies:
+            TimeBasedTriggeringPolicy:
+              interval: 1
+              modulate: true
+            SizeBasedTriggeringPolicy:
+              size: 1 GB
+          # Delete file older than 30days
+          DefaultRolloverStrategy:
+              Delete:
+                basePath: ${sys:pulsar.log.dir}
+                maxDepth: 2
+                IfFileName:
+                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                IfLastModified:
+                  age: 30d
+  
+        Prometheus:
+          name: Prometheus
+  
+        # Routing
+        Routing:
+          name: RoutingAppender
+          Routes:
+            pattern: "$${ctx:function}"
+            Route:
+              -
+                Routing:
+                  name: InstanceRoutingAppender
+                  Routes:
+                    pattern: "$${ctx:instance}"
+                    Route:
+                      -
+                        RollingFile:
+                          name: "Rolling-${ctx:function}"
+                          fileName : "${sys:pulsar.log.dir}/functions/${ctx:function}/${ctx:functionname}-${ctx:instance}.log"
+                          filePattern : "${sys:pulsar.log.dir}/functions/${sys:pulsar.log.file}-${ctx:instance}-%d{MM-dd-yyyy}-%i.log.gz"
+                          PatternLayout:
+                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                          Policies:
+                            TimeBasedTriggeringPolicy:
+                              interval: 1
+                              modulate: true
+                            SizeBasedTriggeringPolicy:
+                              size: "20MB"
+                            # Trigger every day at midnight that also scan
+                            # roll-over strategy that deletes older file
+                            CronTriggeringPolicy:
+                              schedule: "0 0 0 * * ?"
+                          # Delete file older than 30days
+                          DefaultRolloverStrategy:
+                              Delete:
+                                basePath: ${sys:pulsar.log.dir}
+                                maxDepth: 2
+                                IfFileName:
+                                  glob: "*/${sys:pulsar.log.file}*log.gz"
+                                IfLastModified:
+                                  age: 30d
+                      - ref: "${sys:pulsar.routing.appender.default}"
+                        key: "${ctx:function}"
+              - ref: "${sys:pulsar.routing.appender.default}"
+                key: "${ctx:function}"
+  
+      Loggers:
+  
+        # Default root logger configuration
+        Root:
+          level: "${sys:pulsar.log.root.level}"
+          additivity: true
+          AppenderRef:
+            - ref: "${sys:pulsar.log.appender}"
+              level: "${sys:pulsar.log.level}"
+            - ref: Prometheus
+              level: info
+  
+        Logger:
+          - name: org.apache.bookkeeper.bookie.BookieShell
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+          - name: verbose
+            level: info
+            additivity: false
+            AppenderRef:
+              - ref: Console
+  
+        # Logger to inject filter script
+    #     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
+    #       level: debug
+    #       additivity: false
+    #       AppenderRef:
+    #         ref: "${sys:pulsar.log.appender}"
+    #         ScriptFilter:
+    #           onMatch: ACCEPT
+    #           onMisMatch: DENY
+    #           ScriptRef:
+    #             ref: filter.js
+---
+# Source: pulsar/templates/prometheus/prometheus-pvc.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "pulsar-prometheus-data"
+  namespace: pulsar
+  labels:
+    localstorage.hwameistor.io/storage-type: dvol
+spec:
+  resources:
+    requests:
+      storage: 10Gi
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "local-storage-hdd-lvm"
+---
+# Source: pulsar/templates/pulsar-manager/pulsar-manager-pvc.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "pulsar-pulsar-manager-data"
+  namespace: pulsar
+  labels:
+    localstorage.hwameistor.io/storage-type: dvol
+spec:
+  resources:
+    requests:
+      storage: 10Gi
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "local-storage-hdd-lvm"
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    release: pulsar
+    heritage: Helm
+  name: pulsar-promtail-clusterrole
+  namespace: pulsar
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "watch", "list"]
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: "pulsar-bookie-clusterrole"
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+rules:
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+    - pods
+  verbs:
+    - list
+    - get
+---
+# Source: pulsar/templates/broker/broker-cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: "pulsar-broker-clusterrole"
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+rules:
+- apiGroups: [""]
+  resources:
+  - configmap
+  - configmaps
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["", "extensions", "apps"]
+  resources:
+    - pods
+    - services
+    - deployments
+    - secrets
+    - statefulsets
+  verbs:
+    - list
+    - watch
+    - get
+    - update
+    - create
+    - delete
+    - patch
+---
+# Source: pulsar/templates/prometheus/pulsar-operators-rbac.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: "pulsar-pulsar-operator"
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
+    - namespaces
+    - persistentvolumes
+    - persistentvolumeclaims
+  verbs:
+    - list
+    - watch
+    - get
+    - create
+- apiGroups: ["", "extensions", "apps"]
+  resources:
+    - pods
+    - deployments
+    - ingresses
+    - secrets
+    - statefulsets
+  verbs:
+    - list
+    - watch
+    - get
+    - update
+    - create
+    - delete
+    - patch
+- apiGroups: [""]
+  resources:
+    - replicasets
+  verbs:
+    - list
+    - watch
+    - get
+- apiGroups: [""]
+  resources:
+    - events
+  verbs:
+    - list
+    - watch
+    - get
+- apiGroups:
+    - "rbac.authorization.k8s.io"
+  resources:
+    - clusterrolebindings
+    - clusterroles
+  verbs:
+    - "*"
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pulsar-promtail-clusterrolebinding
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    release: pulsar
+    heritage: Helm
+subjects:
+  - kind: ServiceAccount
+    name: pulsar-promtail
+    namespace: pulsar
+roleRef:
+  kind: ClusterRole
+  name: pulsar-promtail-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-cluster-role-binding.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+## TODO create our own cluster role with less privledges than admin
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "pulsar-bookie-clusterrolebinding"
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "pulsar-bookie-clusterrole"
+subjects:
+- kind: ServiceAccount
+  name: pulsar-bookie-acct
+  namespace: pulsar
+---
+# Source: pulsar/templates/broker/broker-cluster-role-binding.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+## TODO create our own cluster role with less privledges than admin
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "pulsar-broker-clusterrolebinding"
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "pulsar-broker-clusterrole"
+subjects:
+- kind: ServiceAccount
+  name: pulsar-broker-acct
+  namespace: pulsar
+---
+# Source: pulsar/templates/prometheus/pulsar-operators-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: "pulsar-pulsar-operator-cluster-role-binding"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "pulsar-pulsar-operator"
+subjects:
+- kind: ServiceAccount
+  name: pulsar-pulsar-operator
+  namespace: pulsar
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pulsar-loki
+  namespace: pulsar
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    heritage: Helm
+    release: pulsar
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [pulsar-loki]
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pulsar-promtail
+  namespace: pulsar
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    heritage: Helm
+    release: pulsar
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [pulsar-promtail]
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pulsar-loki
+  namespace: pulsar
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    heritage: Helm
+    release: pulsar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pulsar-loki
+subjects:
+- kind: ServiceAccount
+  name: pulsar-loki
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pulsar-promtail
+  namespace: pulsar
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    heritage: Helm
+    release: pulsar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pulsar-promtail
+subjects:
+- kind: ServiceAccount
+  name: pulsar-promtail
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pulsar-loki-headless
+  namespace: pulsar
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    release: pulsar
+    heritage: Helm
+    variant: headless
+spec:
+  clusterIP: None
+  ports:
+    - port: 3100
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    app: loki
+    release: pulsar
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pulsar-loki
+  namespace: pulsar
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    release: pulsar
+    heritage: Helm
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3100
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    app: loki
+    release: pulsar
+---
+# Source: pulsar/templates/alert-manager/alertmanager-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-alert-manager"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: alert-manager
+  annotations:
+            {}
+spec:
+  clusterIP: None
+  ports:
+    - name: server
+      port: 9093
+  selector:
+    app: pulsar
+    release: pulsar
+    component: alert-manager
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-autorecovery-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-recovery"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: recovery
+spec:
+  ports:
+  - name: http
+    port: 8000
+  clusterIP: None
+  selector:
+    app: pulsar
+    release: pulsar
+    component: recovery
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-bookie"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: bookie
+  annotations:
+    publishNotReadyAddresses: "true"
+spec:
+  ports:
+  - name: bookie
+    port: 3181
+  - name: http
+    port: 8000
+  clusterIP: None
+  selector:
+    app: pulsar
+    release: pulsar
+    component: bookie
+  # bookkeeper uses statefulset for getting stable bookie identifier.
+  # it is okay to publish endpoints that are not ready because bookkeeper client
+  # already has the ability to handle bookie failures.
+  publishNotReadyAddresses: true
+---
+# Source: pulsar/templates/broker/broker-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-broker"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: broker
+  annotations:
+    {}
+spec:
+  ports:
+  # prometheus needs to access /metrics endpoint
+  - name: http
+    port: 8080
+  - name: pulsar
+    port: 6650
+  clusterIP: None
+  selector:
+    app: pulsar
+    release: pulsar
+    component: broker
+---
+# Source: pulsar/templates/grafana/grafana-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-grafana"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: grafana
+  annotations:
+spec:
+  clusterIP: None
+  ports:
+    - name: server
+      port: 3000
+      protocol: TCP
+  selector:
+    app: pulsar
+    release: pulsar
+    component: grafana
+---
+# Source: pulsar/templates/prometheus/prometheus-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-prometheus"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: prometheus
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  ports:
+    - name: server
+      port: 9090
+  selector:
+    app: pulsar
+    release: pulsar
+    component: prometheus
+---
+# Source: pulsar/templates/proxy/proxy-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-proxy"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: proxy
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+    - name: pulsar
+      port: 6650
+      protocol: TCP
+  selector:
+    app: pulsar
+    release: pulsar
+    component: proxy
+---
+# Source: pulsar/templates/pulsar-manager/pulsar-manager-backend-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-pulsar-manager-backend"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: pulsar-manager
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  ports:
+    - name: backend
+      port: 7750
+      protocol: TCP
+  selector:
+    app: pulsar
+    release: pulsar
+    component: pulsar-manager
+---
+# Source: pulsar/templates/pulsar-manager/pulsar-manager-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-pulsar-manager"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: pulsar-manager
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  ports:
+    - name: frontend
+      port: 9527
+      protocol: TCP
+  selector:
+    app: pulsar
+    release: pulsar
+    component: pulsar-manager
+---
+# Source: pulsar/templates/toolset/toolset-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-toolset"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: toolset
+spec:
+  clusterIP: None
+  selector:
+    app: pulsar
+    release: pulsar
+    component: toolset
+---
+# Source: pulsar/templates/zookeeper/zookeeper-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# deploy zookeeper only when `components.zookeeper` is true
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pulsar-zookeeper"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: zookeeper
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  ports:
+    - name: follower
+      port: 2888
+    - name: leader-election
+      port: 3888
+    - name: client
+      port: 2181
+  clusterIP: None
+  selector:
+    app: pulsar
+    release: pulsar
+    component: zookeeper
+---
+# Source: pulsar/charts/loki-stack/charts/promtail/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: pulsar-promtail
+  namespace: pulsar
+  labels:
+    app: promtail
+    chart: promtail-0.22.1
+    release: pulsar
+    heritage: Helm
+  annotations:
+    {}
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+      release: pulsar
+  updateStrategy:
+    {}
+  template:
+    metadata:
+      labels:
+        app: promtail
+        release: pulsar          
+      annotations:
+        checksum/config: 7820e66a31c7c73e77e6745964f6f1a5ccff5702694b0d9c18d8b164efff83c9
+        prometheus.io/port: http-metrics
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: pulsar-promtail
+      containers:
+        - name: promtail
+          image: "grafana/promtail:1.4.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-config.file=/etc/promtail/promtail.yaml"
+            - "-client.url=http://pulsar-loki:3100/loki/api/v1/push"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: run
+              mountPath: /run/promtail
+            - mountPath: /var/lib/docker/containers
+              name: docker
+              readOnly: true
+            - mountPath: /var/log/pods
+              name: pods
+              readOnly: true
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 3101
+              name: http-metrics
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsUser: 0
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            {}
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: pulsar-promtail
+        - name: run
+          hostPath:
+            path: /run/promtail
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: docker
+        - hostPath:
+            path: /var/log/pods
+          name: pods
+---
+# Source: pulsar/templates/node-exporter/node-exporter.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "pulsar-node-exporter"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: node-exporter
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: node-exporter
+  updateStrategy:
+    type: OnDelete
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: node-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+    spec:
+      containers:
+        - name: prometheus-node-exporter
+          image: "prom/node-exporter:v0.16.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+          ports:
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+---
+# Source: pulsar/templates/grafana/grafana-deployment.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "pulsar-grafana"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: grafana
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: grafana
+      annotations:
+        checksum/config: a136d5b50d0315ac0d695b179d05dcc4250ee07b5e83d1210d59ab1ce3d817e8
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: "pulsar-grafana"
+        image: "streamnative/apache-pulsar-grafana-dashboard-k8s:0.0.11"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 0.1
+            memory: 250Mi
+        ports:
+        - name: server
+          containerPort: 3000
+        env:
+        # for supporting apachepulsar/pulsar-grafana
+        - name: PROMETHEUS_URL
+          value: http://pulsar-prometheus:9090/
+        # for supporting streamnative/apache-pulsar-grafana-dashboard
+        - name: PULSAR_PROMETHEUS_URL
+          value: http://pulsar-prometheus:9090/
+        - name: PULSAR_CLUSTER
+          value: pulsar
+        - name: GF_LOKI_URL
+          value: http://pulsar-loki.pulsar.svc.cluster.local:3100/
+        - name: GF_LOKI_DATASOURCE_NAME
+          value: pulsar-loki
+        - name: GRAFANA_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: "pulsar-grafana-secret"
+              key: GRAFANA_ADMIN_USER
+        - name: GRAFANA_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "pulsar-grafana-secret"
+              key: GRAFANA_ADMIN_PASSWORD
+        - name: GRAFANA_CFG_FILE
+          value: /pulsar/conf/grafana.ini
+        - name: GRAFANA_DOMAIN
+          value: admin.pulsar.test.pulsar.example.local
+        - name: GRAFANA_ROOT_URL
+          value: /grafana/
+        - name: GRAFANA_SERVE_FROM_SUB_PATH
+          value: "true"
+        volumeMounts:
+        - name: "cfg"
+          mountPath: "/pulsar/conf/grafana.ini"
+          subPath: grafana.ini
+      volumes:
+      - name: "cfg"
+        configMap:
+          name: "pulsar-grafana"
+---
+# Source: pulsar/charts/loki-stack/charts/loki/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pulsar-loki
+  namespace: pulsar
+  labels:
+    app: loki
+    chart: loki-0.28.1
+    release: pulsar
+    heritage: Helm
+  annotations:
+    {}
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+      release: pulsar
+  serviceName: pulsar-loki-headless
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: loki
+        name: loki
+        release: pulsar
+      annotations:
+        checksum/config: 895d164bd7c81ffe9a9f434db1d0c409e05f0add9b9239267121aacf31f17300
+        prometheus.io/port: http-metrics
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: pulsar-loki
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      initContainers:
+        []
+      containers:
+        - name: loki
+          image: "grafana/loki:1.4.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-config.file=/etc/loki/loki.yaml"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: storage
+              mountPath: "/data"
+              subPath: 
+          ports:
+            - name: http-metrics
+              containerPort: 3100
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            {}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 4800
+      volumes:
+        - name: config
+          secret:
+            secretName: pulsar-loki
+        - name: storage
+          emptyDir: {}
+---
+# Source: pulsar/templates/alert-manager/alertmanager-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-alert-manager"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: alert-manager
+spec:
+  serviceName: "pulsar-alert-manager"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: alert-manager
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: alert-manager
+      annotations:
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: pulsar-alert-manager-configmap-reload
+        image: "jimmidyson/configmap-reload:v0.3.0"
+        imagePullPolicy: "IfNotPresent"
+        args:
+          - --volume-dir=/etc/config
+          - --webhook-url=http://127.0.0.1:9093/-/reload
+        resources:
+            {}
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+            readOnly: true
+      - name: "pulsar-alert-manager"
+        image: "prom/alertmanager:v0.20.0"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 0.1
+            memory: 250Mi
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        args:
+          - --config.file=/etc/config/alertmanager.yml
+          - --cluster.advertise-address=$(POD_IP):6783
+          - --storage.path=/alertmanager
+        ports:
+        - name: server
+          containerPort: 9093
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9093
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: "pulsar-alert-manager"
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-recovery"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: recovery
+spec:
+  serviceName: "pulsar-recovery"
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  # nodeSelector:
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: recovery
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: recovery
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        checksum/config: 66dbd930d6402fcb14b0fb4f84c94637d316662de434b957e0219608eed1671f
+    spec:
+      securityContext:
+      affinity:
+      terminationGracePeriodSeconds: 30
+      initContainers:
+      # This initContainer will wait for bookkeeper initnewcluster to complete
+      # before deploying the bookies
+      - name: pulsar-bookkeeper-verify-clusterid
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+        - >
+          bin/apply-config-from-env.py conf/bookkeeper.conf;until bin/bookkeeper shell whatisinstanceid; do
+            sleep 3;
+          done;
+        envFrom:
+        - configMapRef:
+            name: "pulsar-recovery"
+        volumeMounts:
+        
+      containers:
+      - name: "pulsar-recovery"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 0.05
+            memory: 64Mi
+        command: ["sh", "-c"]
+        args:
+        - >
+          bin/apply-config-from-env.py conf/bookkeeper.conf;
+          
+          bin/bookkeeper autorecovery
+        ports:
+        - name: http
+          containerPort: 8000
+        envFrom:
+        - configMapRef:
+            name: "pulsar-recovery"
+        volumeMounts:
+        
+        - name: "pulsar-recovery-log4j2"
+          mountPath: "/pulsar/conf/log4j2.yaml"
+          subPath: log4j2.yaml
+      volumes:
+      
+      - name: "pulsar-recovery-log4j2"
+        configMap:
+          name: "pulsar-recovery"
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-bookie"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: bookie
+spec:
+  serviceName: "pulsar-bookie"
+  replicas: 4
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: bookie
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: bookie
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        checksum/config: 053d9fc604f6126cd2082ae8a6de7998487ae63873a53e7c5c53339f0e86284e
+    spec:
+      schedulerName: hwameistor-scheduler
+      securityContext:
+      serviceAccountName: pulsar-bookie-acct
+      affinity:
+      terminationGracePeriodSeconds: 30
+      initContainers:
+      # This initContainer will wait for bookkeeper initnewcluster to complete
+      # before deploying the bookies
+      - name: pulsar-bookkeeper-verify-clusterid
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+        # only reformat bookie if bookkeeper is running without persistence
+        - >
+          
+          set -e;
+          bin/apply-config-from-env.py conf/bookkeeper.conf;until bin/bookkeeper shell whatisinstanceid; do
+            sleep 3;
+          done;
+        envFrom:
+        - configMapRef:
+            name: "pulsar-bookie"
+        volumeMounts:
+        
+      containers:
+      - name: "pulsar-bookie"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /api/v1/bookie/state
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          failureThreshold: 60
+        readinessProbe:
+          httpGet:
+            path: /api/v1/bookie/is_ready
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          failureThreshold: 60
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 512Mi
+        command: ["bash", "-c"]
+        args:
+        - >
+          bin/apply-config-from-env.py conf/bookkeeper.conf;
+          
+          bin/pulsar bookie;
+        ports:
+        - name: bookie
+          containerPort: 3181
+        - name: http
+          containerPort: 8000
+        envFrom:
+        - configMapRef:
+            name: "pulsar-bookie"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: VOLUME_NAME
+          value: "pulsar-bookie-journal"
+        - name: BOOKIE_PORT
+          value: "3181"
+        - name: BOOKIE_RACK_AWARE_ENABLED
+          value: "true"
+        volumeMounts:
+        - name: "pulsar-bookie-journal"
+          mountPath: /pulsar/data/bookkeeper/journal
+        - name: "pulsar-bookie-ledgers"
+          mountPath: /pulsar/data/bookkeeper/ledgers
+        
+        - name: "pulsar-bookie-log4j2"
+          mountPath: "/pulsar/conf/log4j2.yaml"
+          subPath: log4j2.yaml
+      volumes:
+      
+      - name: "pulsar-bookie-log4j2"
+        configMap:
+          name: "pulsar-bookie"
+  volumeClaimTemplates:
+  - metadata:
+      name: "pulsar-bookie-journal"
+      labels:
+        localstorage.hwameistor.io/storage-type: dvol
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: "local-storage-hdd-lvm"
+  - metadata:
+      name: "pulsar-bookie-ledgers"
+      labels:
+        localstorage.hwameistor.io/storage-type: dvol
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: "local-storage-hdd-lvm"
+---
+# Source: pulsar/templates/broker/broker-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-broker"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: broker
+spec:
+  serviceName: "pulsar-broker"
+  replicas: 3
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: broker
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: broker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        checksum/config: c37ae9adda4fde4c5f847b6dca9efbd7deebefc96afddf77115d41458bc1a0cb
+    spec:
+      securityContext:
+      serviceAccountName: pulsar-broker-acct
+      affinity:
+      terminationGracePeriodSeconds: 30
+      initContainers:
+      # This init container will wait for zookeeper to be ready before
+      # deploying the bookies
+      - name: wait-zookeeper-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >-
+            
+            until bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server pulsar-zookeeper:2181 get /admin/clusters/pulsar; do
+              echo "pulsar cluster pulsar isn't initialized yet ... check in 3 seconds ..." && sleep 3;
+            done;
+        volumeMounts:
+        
+      # This init container will wait for bookkeeper to be ready before
+      # deploying the broker
+      - name: wait-bookkeeper-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >
+            
+            bin/apply-config-from-env.py conf/bookkeeper.conf;
+            until bin/bookkeeper shell whatisinstanceid; do
+              echo "bookkeeper cluster is not initialized yet. backoff for 3 seconds ...";
+              sleep 3;
+            done;
+            echo "bookkeeper cluster is already initialized";
+            bookieServiceNumber="$(nslookup -timeout=10 pulsar-bookie | grep Name | wc -l)";
+            until [ ${bookieServiceNumber} -ge 3 ]; do
+              echo "bookkeeper cluster pulsar isn't ready yet ... check in 10 seconds ...";
+              sleep 10;
+              bookieServiceNumber="$(nslookup -timeout=10 pulsar-bookie | grep Name | wc -l)";
+            done;
+            echo "bookkeeper cluster is ready";
+        envFrom:
+          - configMapRef:
+              name: "pulsar-bookie"
+        volumeMounts:
+          
+      containers:
+      - name: "pulsar-broker"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /status.html
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        readinessProbe:
+          httpGet:
+            path: /status.html
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 512Mi
+        command: ["sh", "-c"]
+        args:
+        - >
+          
+          bin/apply-config-from-env.py conf/broker.conf;
+          echo "OK" > status;
+          
+          bin/pulsar zookeeper-shell -server pulsar-zookeeper:2181 get /loadbalance/brokers/${HOSTNAME}.pulsar-broker.pulsar.svc.cluster.local:8080;
+          while [ $? -eq 0 ]; do
+            echo "broker ${HOSTNAME}.pulsar-broker.pulsar.svc.cluster.local znode still exists ... check in 10 seconds ...";
+            sleep 10;
+            bin/pulsar zookeeper-shell -server pulsar-zookeeper:2181 get /loadbalance/brokers/${HOSTNAME}.pulsar-broker.pulsar.svc.cluster.local:8080;
+          done;
+          bin/pulsar broker;
+        ports:
+        # prometheus needs to access /metrics endpoint
+        - name: http
+          containerPort: 8080
+        - name: pulsar
+          containerPort: 6650
+        env:
+        envFrom:
+        - configMapRef:
+            name: "pulsar-broker"
+        volumeMounts:
+          
+          - name: "pulsar-broker-log4j2"
+            mountPath: "/pulsar/conf/log4j2.yaml"
+            subPath: log4j2.yaml
+          
+          
+          
+          
+          - name: "function-worker-config"
+            mountPath: "/pulsar/conf/functions_worker.yml"
+            subPath: functions_worker.yml
+      volumes:
+      
+      
+      - name: "pulsar-broker-log4j2"
+        configMap:
+          name: "pulsar-broker"
+      
+      
+      
+      - name: "function-worker-config"
+        configMap:
+          name: "pulsar-functions-worker-configfile"
+---
+# Source: pulsar/templates/prometheus/prometheus-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-prometheus"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: prometheus
+spec:
+  serviceName: "pulsar-prometheus"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: prometheus
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: prometheus
+      annotations:
+    spec:
+      serviceAccount: pulsar-pulsar-operator
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      containers:
+      - name: pulsar-prometheus-configmap-reload
+        image: "jimmidyson/configmap-reload:v0.3.0"
+        imagePullPolicy: "IfNotPresent"
+        args:
+          - --volume-dir=/etc/config
+          - --webhook-url=http://127.0.0.1:9090/-/reload
+        resources:
+          {}
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+            readOnly: true 
+      - name: "pulsar-prometheus"
+        image: "prom/prometheus:v2.17.2"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 0.1
+            memory: 256Mi
+        args:
+          - --config.file=/etc/config/prometheus.yml
+          - --storage.tsdb.retention.time=15d
+          - --storage.tsdb.path=/prometheus
+          - --web.console.libraries=/etc/prometheus/console_libraries
+          - --web.console.templates=/etc/prometheus/consoles
+          - --web.enable-lifecycle
+        ports:
+        - name: server
+          containerPort: 9090
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9090
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+        - name: "pulsar-prometheus-data"
+          mountPath: /prometheus
+        
+      volumes:
+      - name: config-volume
+        configMap:
+          name: "pulsar-prometheus"
+      - name: "pulsar-prometheus-data"
+        persistentVolumeClaim:
+          claimName: "pulsar-prometheus-data"
+---
+# Source: pulsar/templates/proxy/proxy-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-proxy"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: proxy
+spec:
+  serviceName: "pulsar-proxy"
+  replicas: 3
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: proxy
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: proxy
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        checksum/config: 014fb90ee7d8726c501220b268b94e4cc209d40e71417094045d8a4b2a46dd85
+    spec:
+      securityContext:
+      serviceAccountName: pulsar-proxy-acct
+      affinity:
+      terminationGracePeriodSeconds: 30
+      initContainers:
+      # This init container will wait for zookeeper to be ready before
+      # deploying the bookies
+      - name: wait-zookeeper-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >-
+            until bin/pulsar zookeeper-shell -server pulsar-zookeeper get /admin/clusters/pulsar; do
+              sleep 3;
+            done;
+      # This init container will wait for at least one broker to be ready before
+      # deploying the proxy
+      - name: wait-broker-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >-
+            set -e;
+            brokerServiceNumber="$(nslookup -timeout=10 pulsar-broker | grep Name | wc -l)";
+            until [ ${brokerServiceNumber} -ge 1 ]; do
+              echo "pulsar cluster pulsar isn't initialized yet ... check in 10 seconds ...";
+              sleep 10;
+              brokerServiceNumber="$(nslookup -timeout=10 pulsar-broker | grep Name | wc -l)";
+            done;
+      containers:
+      - name: "pulsar-proxy"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /status.html
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        readinessProbe:
+          httpGet:
+            path: /status.html
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 128Mi
+        command: ["sh", "-c"]
+        args:
+        - >
+          bin/apply-config-from-env.py conf/proxy.conf;
+          echo "OK" > status;
+          bin/pulsar proxy;
+        ports:
+        # prometheus needs to access /metrics endpoint
+        - name: http
+          containerPort: 8080
+        - name: pulsar
+          containerPort: 6650
+        envFrom:
+        - configMapRef:
+            name: "pulsar-proxy"
+        volumeMounts:
+          - name: "pulsar-proxy-log4j2"
+            mountPath: "/pulsar/conf/log4j2.yaml"
+            subPath: log4j2.yaml
+          
+          
+      volumes:
+        - name: "pulsar-proxy-log4j2"
+          configMap:
+            name: "pulsar-proxy"
+---
+# Source: pulsar/templates/pulsar-manager/pulsar-manager-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-pulsar-manager"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: pulsar-manager
+spec:
+  serviceName: "pulsar-pulsar-manager"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: pulsar-manager
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: pulsar-manager
+      annotations:
+        checksum/config: 2076a0995aaf91b6914f5cfb07a0121f46e74e0963afc2885a96f842e97bbc33
+    spec:
+      terminationGracePeriodSeconds: 0
+      initContainers:
+      # This init container will wait for broker to be ready before
+      # deploying the pulsar manager
+      - name: wait-broker-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >
+            brokerServiceNumber="$(nslookup -timeout=10 pulsar-broker | grep Name | wc -l)";
+            until [ ${brokerServiceNumber} -ge 1 ]; do
+              echo "broker cluster pulsar isn't ready yet ... check in 10 seconds ...";
+              sleep 10;
+              brokerServiceNumber="$(nslookup -timeout=10 pulsar-broker | grep Name | wc -l)";
+            done;
+            echo "broker cluster is ready";
+      containers:
+        - name: "pulsar-pulsar-manager"
+          image: "streamnative/pulsar-manager:0.3.0"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 0.1
+              memory: 250Mi
+          readinessProbe:
+            tcpSocket:
+              port: 7750
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 10
+          livenessProbe:
+            tcpSocket:
+              port: 7750
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 10
+          command: ["sh", "-c"]
+          args:
+            - >
+              /pulsar-manager/pulsar-manager.sh
+          ports:
+          - name: frontend
+            containerPort: 9527
+          - name: backend
+            containerPort: 7750
+          volumeMounts:
+          - name: pulsar-manager-data
+            mountPath: /data
+          - name: pulsar-manager-script
+            mountPath: "/pulsar-manager/pulsar-manager.sh"
+            subPath: entrypoint.sh
+          - name: pulsar-manager-backend-script
+            mountPath: "/pulsar-manager/pulsar-backend-entrypoint.sh"
+            subPath: backend_entrypoint.sh
+          
+          
+      volumes:
+      - name: pulsar-manager-data
+        persistentVolumeClaim:
+          claimName: "pulsar-pulsar-manager-data"
+      - name: pulsar-manager-script
+        configMap:
+          name: "pulsar-pulsar-manager-configmap"
+          defaultMode: 0755
+      - name: pulsar-manager-backend-script
+        configMap:
+          name: "pulsar-pulsar-manager-configmap"
+          defaultMode: 0755
+---
+# Source: pulsar/templates/toolset/toolset-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-toolset"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: toolset
+spec:
+  serviceName: "pulsar-toolset"
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: toolset
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: toolset
+      annotations:
+        checksum/config: dede1aa6609a4fbe87852197e4d00df54bba87d72fcefc0d3bca5c3eb2c30861
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: "pulsar"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 0.1
+            memory: 256Mi
+        command: ["sh", "-c"]
+        args:
+        - >
+          bin/apply-config-from-env.py conf/client.conf;
+          bin/apply-config-from-env.py conf/bookkeeper.conf;
+          
+          sleep 10000000000
+        envFrom:
+        - configMapRef:
+            name: "pulsar-toolset"
+        volumeMounts:
+        
+        
+        - name: "pulsar-toolset-log4j2"
+          mountPath: "/pulsar/conf/log4j2.yaml"
+          subPath: log4j2.yaml
+      volumes:
+      
+      
+      - name: "pulsar-toolset-log4j2"
+        configMap:
+          name: "pulsar-toolset"
+---
+# Source: pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# deploy zookeeper only when `components.zookeeper` is true
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "pulsar-zookeeper"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: zookeeper
+spec:
+  serviceName: "pulsar-zookeeper"
+  replicas: 3
+  selector:
+    matchLabels:
+      app: pulsar
+      release: pulsar
+      component: zookeeper
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: OrderedReady
+  template:
+    metadata:
+      labels:
+        app: pulsar
+        release: pulsar
+        cluster: pulsar
+        component: zookeeper
+      annotations:
+        checksum/config: 3b9ead72ba8263bbb93771e2d1de8356e133638ddae2980d2139ecfb57a8b652
+        prometheus.io/port: "8000"
+        prometheus.io/scrape: "true"
+    spec:
+      schedulerName: hwameistor-scheduler
+      securityContext:
+      affinity:
+      terminationGracePeriodSeconds: 30
+      initContainers:
+      containers:
+      - name: "pulsar-zookeeper"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 0.1
+            memory: 256Mi
+        command: ["sh", "-c"]
+        args:
+        - >
+          bin/apply-config-from-env.py conf/zookeeper.conf;
+          
+          bin/gen-zk-conf.sh conf/zookeeper.conf 0 participant;
+          cat conf/zookeeper.conf;
+          bin/pulsar zookeeper;
+        ports:
+        - name: metrics
+          containerPort: 8000
+        - name: client
+          containerPort: 2181
+        - name: follower
+          containerPort: 2888
+        - name: leader-election
+          containerPort: 3888
+        env:
+        - name: ZOOKEEPER_SERVERS
+          value:
+            pulsar-zookeeper-0,pulsar-zookeeper-1,pulsar-zookeeper-2
+        envFrom:
+        - configMapRef:
+            name: "pulsar-zookeeper"
+        readinessProbe:
+          exec:
+            command:
+            - bin/pulsar-zookeeper-ruok.sh
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          failureThreshold: 10
+        livenessProbe:
+          exec:
+            command:
+            - bin/pulsar-zookeeper-ruok.sh
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          failureThreshold: 10
+        volumeMounts:
+        
+        - name: "pulsar-zookeeper-data"
+          mountPath: "/pulsar/data"
+        
+        - name: "pulsar-zookeeper-log4j2"
+          mountPath: "/pulsar/conf/log4j2.yaml"
+          subPath: log4j2.yaml
+        - name: "pulsar-zookeeper-genzkconf"
+          mountPath: "/pulsar/bin/gen-zk-conf.sh"
+          subPath: gen-zk-conf.sh
+      volumes:
+      
+      
+      - name: "pulsar-zookeeper-log4j2"
+        configMap:
+          name: "pulsar-zookeeper"
+      - name: "pulsar-zookeeper-genzkconf"
+        configMap:
+          name: "pulsar-genzkconf-configmap"
+          defaultMode: 0755
+  volumeClaimTemplates:
+  
+  - metadata:
+      name: "pulsar-zookeeper-data"
+      labels:
+        localstorage.hwameistor.io/storage-type: dvol
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: "local-storage-hdd-lvm"
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-cluster-initialize.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "pulsar-bookie-init"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: "bookie-init"
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: wait-zookeeper-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >-
+            until nslookup pulsar-zookeeper-2.pulsar-zookeeper.pulsar; do
+              sleep 3;
+            done;
+      containers:
+      - name: "pulsar-bookie-init"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >
+            bin/apply-config-from-env.py conf/bookkeeper.conf;
+            
+            if bin/bookkeeper shell whatisinstanceid; then
+                echo "bookkeeper cluster already initialized";
+            else
+                bin/bookkeeper shell initnewcluster;
+            fi
+        envFrom:
+        - configMapRef:
+            name: "pulsar-bookie"
+        volumeMounts:
+        
+      volumes:
+      
+      restartPolicy: Never
+---
+# Source: pulsar/templates/pulsar-cluster-initialize.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "pulsar-pulsar-init"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: pulsar-init
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: wait-zookeeper-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >-
+            until nslookup pulsar-zookeeper-2.pulsar-zookeeper.pulsar; do
+              sleep 3;
+            done;
+      # This initContainer will wait for bookkeeper initnewcluster to complete
+      # before initializing pulsar metadata
+      - name: pulsar-bookkeeper-verify-clusterid
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+        - >
+          bin/apply-config-from-env.py conf/bookkeeper.conf;
+          
+          until bin/bookkeeper shell whatisinstanceid; do
+            sleep 3;
+          done;
+        envFrom:
+        - configMapRef:
+            name: "pulsar-bookie"
+        volumeMounts:
+        
+      containers:
+      - name: "pulsar-pulsar-init"
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >
+            
+            bin/pulsar initialize-cluster-metadata \
+              --cluster pulsar \
+              --zookeeper pulsar-zookeeper:2181 \
+              --configuration-store pulsar-zookeeper:2181 \
+              --web-service-url http://pulsar-broker.pulsar.svc.cluster.local:8080/ \
+              --web-service-url-tls https://pulsar-broker.pulsar.svc.cluster.local:8443/ \
+              --broker-service-url pulsar://pulsar-broker.pulsar.svc.cluster.local:6650/ \
+              --broker-service-url-tls pulsar+ssl://pulsar-broker.pulsar.svc.cluster.local:6651/ || true;
+        volumeMounts:
+        
+      volumes:
+      
+      restartPolicy: Never
+---
+# Source: pulsar/templates/pulsar-manager/pulsar-manager-initialize.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "pulsar-pulsar-manager-init"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+    component: pulsar-manager
+spec:
+  template:
+    spec:
+      initContainers:
+      # This init container will wait for bookkeeper to be ready before
+      # deploying the broker
+      - name: wait-pulsar-manager-ready
+        image: "streamnative/pulsar-all:2.6.0-sn-21"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >
+            pmServiceNumber="$(nslookup -timeout=10 pulsar-pulsar-manager-backend | grep Name | wc -l)";
+            until [ ${pmServiceNumber} -ge 1 ]; do
+              echo "Pulsar Manager cluster pulsar isn't ready yet ... check in 10 seconds ...";
+              sleep 10;
+              pmServiceNumber="$(nslookup -timeout=10 pulsar-pulsar-manager-backend | grep Name | wc -l)";
+            done;
+            echo "Pulsar Manager cluster is ready";
+      containers:
+      - name: "pulsar-pulsar-init"
+        image: "streamnative/pulsar-manager:0.3.0"
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c"]
+        args:
+          - >
+            apk add curl;
+            curl -H "Content-Type: application/json" \
+                 -X PUT \
+                 http://pulsar-pulsar-manager-backend:7750/pulsar-manager/users/superuser \
+                 -d '{"name": "pulsarmanager", "password": "welovepulsar", "description": "Pulsar Manager Admin", "email": "support@pulsar.io"}' 
+      restartPolicy: Never
+---
+# Source: pulsar/templates/control-center/control-center-ingress.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "pulsar-control-center-ingress"
+  namespace: pulsar
+  labels:
+    app: pulsar
+    chart: pulsar-1.3.2
+    release: pulsar
+    heritage: Helm
+    cluster: pulsar
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+    kubernetes.io/ingress.class: haproxy
+spec:
+  rules:
+    - host: admin.pulsar.test.pulsar.example.local
+      http:
+        paths:
+          - path: /grafana
+            backend:
+              serviceName: "pulsar-grafana"
+              servicePort: 3000
+          - path: /
+            backend:
+              serviceName: "pulsar-pulsar-manager"
+              servicePort: 9527
+---
+# Source: pulsar/templates/bookkeeper/bookkeeper-storageclass.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/broker/broker-service-ingress.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/control-center/ingress-controller-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/control-center/ingress-controller-deployment.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/control-center/ingress-controller-rbac.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/control-center/ingress-controller-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/detector/pulsar-detector-pdb.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/detector/pulsar-detector-service-account.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/detector/pulsar-detector-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/detector/pulsar-detector-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/external-dns/external-dns-rbac.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/external-dns/external-dns.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/image-puller/daemonset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/image-puller/job.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/image-puller/rbac.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/presto/presto-coordinator-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/presto/presto-coordinator-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/presto/presto-service.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/presto/presto-worker-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/presto/presto-worker-statefulset.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/prometheus/prometheus-storageclass.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/proxy/proxy-service-ingress.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/proxy/websocket-configmap.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/pulsar-manager/pulsar-manager-storageclass.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/tls/keytool.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# script to process key/cert to keystore and truststore
+---
+# Source: pulsar/templates/tls/tls-cert-internal-issuer.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/tls/tls-cert-public-issuer.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/tls/tls-certs-internal.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/tls/tls-certs-public.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+# Source: pulsar/templates/zookeeper/zookeeper-storageclass.yaml
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# deploy zookeeper only when `components.zookeeper` is true
+
+# define the storage class for data directory
+---
+# Source: pulsar/templates/zookeeper/zookeeper-storageclass.yaml
+# define the storage class for dataLog directory
+---
+# Source: pulsar/charts/loki-stack/templates/tests/loki-test-pod.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    "helm.sh/hook": test-success
+  labels:
+    app: loki-stack
+    chart: loki-stack-0.36.1
+    release: pulsar
+    heritage: Helm
+  name: pulsar-loki-stack-test
+spec:
+  containers:
+  - name: test
+    image: bats/bats:v1.1.0
+    args:
+    - /var/lib/loki/test.sh
+    env:
+    - name: LOKI_SERVICE
+      value: pulsar-loki
+    - name: LOKI_PORT
+      value: "3100"
+    volumeMounts:
+    - name: tests
+      mountPath: /var/lib/loki
+  restartPolicy: Never
+  volumes:
+  - name: tests
+    configMap:
+      name: pulsar-loki-stack-test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Reorganize deploy dir to make the deployment directory simpler

#### Special notes for your reviewer:
##### What it looks like
```shell
➜  hwameistor git:(reorganize-deploy-dir) tree deploy
deploy
├── hwameistor.yaml
├── samples
│   ├── ioping-disk-fs.yaml
│   ├── ioping-disk.yaml
│   ├── nginx-lvm-ha.yaml
│   ├── nginx-lvm-sts.yaml
│   ├── nginx-lvm.yaml
│   └── resources
│       └── localdiskclaim.yaml
└── solutions
    └── pulsar
        └── pulsar.yaml

4 directories, 8 files
```
* **hwameistor.yaml:** `main deploy yaml`, hwameistor will be install totally by applying this yaml
* **samples:** some `workload deploy samples` which use PVs provisioned by hwameistor
* **solutions:** some `third-party middleware deploy samples` which use PVs provisioned by hwameistor
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
