### PR TITLE
ci: fix arm64 builder error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ compile: compile_ldm compile_ls compile_scheduler
 image: build_ldm_image build_ls_image build_scheduler_image
 
 .PHONY: release
-release: release_ldm release_ls
+release: _enable_buildx release_ldm release_ls release_scheduler
 
 .PHONY: unit-test
 unit-test:
@@ -36,7 +36,7 @@ release_ldm:
 	${DOCKER_MAKE_CMD} make compile_ldm
 	${DOCKER_BUILDX_CMD_AMD64} -t ${LDM_IMAGE_NAME}:${RELEASE_TAG}-amd64 -f ${LDM_IMAGE_DOCKERFILE} ${PROJECT_SOURCE_CODE_DIR}
 	# build for arm64 version
-	${DOCKER_MAKE_CMD} make compile_arm64
+	${DOCKER_MAKE_CMD} make compile_ldm_arm64
 	${DOCKER_BUILDX_CMD_ARM64} -t ${LDM_IMAGE_NAME}:${RELEASE_TAG}-arm64 -f ${LDM_IMAGE_DOCKERFILE} ${PROJECT_SOURCE_CODE_DIR}
 	# push to a public registry
 	${MUILT_ARCH_PUSH_CMD} ${LDM_IMAGE_NAME}:${RELEASE_TAG}
@@ -47,7 +47,7 @@ release_ls:
 	${DOCKER_MAKE_CMD} make compile_ls
 	${DOCKER_BUILDX_CMD_AMD64} -t ${LS_IMAGE_NAME}:${RELEASE_TAG}-amd64 -f ${LS_IMAGE_DOCKERFILE} ${PROJECT_SOURCE_CODE_DIR}
 	# build for arm64 version
-	${DOCKER_MAKE_CMD} make compile_arm64
+	${DOCKER_MAKE_CMD} make compile_ls_arm64
 	${DOCKER_BUILDX_CMD_ARM64} -t ${LS_IMAGE_NAME}:${RELEASE_TAG}-arm64 -f ${LS_IMAGE_DOCKERFILE} ${PROJECT_SOURCE_CODE_DIR}
 	# push to a public registry
 	${MUILT_ARCH_PUSH_CMD} ${LS_IMAGE_NAME}:${RELEASE_TAG}
@@ -58,7 +58,7 @@ release_scheduler:
 	${DOCKER_MAKE_CMD} make compile_scheduler
 	${DOCKER_BUILDX_CMD_AMD64} -t ${SCHEDULER_IMAGE_NAME}:${RELEASE_TAG}-amd64 -f ${SCHEDULER_IMAGE_DOCKERFILE} ${PROJECT_SOURCE_CODE_DIR}
 	# build for arm64 version
-	${DOCKER_MAKE_CMD} make compile_arm64
+	${DOCKER_MAKE_CMD} make compile_scheduler_arm64
 	${DOCKER_BUILDX_CMD_ARM64} -t ${SCHEDULER_IMAGE_NAME}:${RELEASE_TAG}-arm64 -f ${SCHEDULER_IMAGE_DOCKERFILE} ${PROJECT_SOURCE_CODE_DIR}
 	# push to a public registry
 	${MUILT_ARCH_PUSH_CMD} ${SCHEDULER_IMAGE_NAME}:${RELEASE_TAG}
@@ -99,10 +99,35 @@ _gen-apis:
 compile_ldm:
 	GOARCH=amd64 ${BUILD_ENVS} ${BUILD_CMD} ${BUILD_OPTIONS} -o ${LDM_BUILD_OUTPUT} ${LDM_BUILD_INPUT}
 
+.PHONY: compile_ldm_arm64
+compile_ldm_arm64:
+	GOARCH=arm64 ${BUILD_ENVS} ${BUILD_CMD} ${BUILD_OPTIONS} -o ${LDM_BUILD_OUTPUT} ${LDM_BUILD_INPUT}
+
 .PHONY: compile_ls
 compile_ls:
 	GOARCH=amd64 ${BUILD_ENVS} ${BUILD_CMD} ${BUILD_OPTIONS} -o ${LS_BUILD_OUTPUT} ${LS_BUILD_INPUT}
 
+.PHONY: compile_ls_arm64
+compile_ls_arm64:
+	GOARCH=arm64 ${BUILD_ENVS} ${BUILD_CMD} ${BUILD_OPTIONS} -o ${LS_BUILD_OUTPUT} ${LS_BUILD_INPUT}
+
 .PHONY: compile_scheduler
 compile_scheduler:
 	GOARCH=amd64 ${BUILD_ENVS} ${BUILD_CMD} ${BUILD_OPTIONS} -o ${SCHEDULER_BUILD_OUTPUT} ${SCHEDULER_BUILD_INPUT}
+
+.PHONY: compile_scheduler_arm64
+compile_scheduler_arm64:
+	GOARCH=arm64 ${BUILD_ENVS} ${BUILD_CMD} ${BUILD_OPTIONS} -o ${SCHEDULER_BUILD_OUTPUT} ${SCHEDULER_BUILD_INPUT}
+
+.PHONY: _enable_buildx
+_enable_buildx:
+	@echo "Checking if buildx enabled"
+	@if [[ "$(shell docker version -f '{{.Server.Experimental}}')" == "true" ]]; \
+	then \
+		docker buildx inspect mutil-platform-builder &>/dev/null; \
+	        [ $$? == 0 ] && echo "ok" && exit 0; \
+		docker buildx create --name mutil-platform-builder &>/dev/null&& echo "ok" && exit 0; \
+	else \
+		echo "experimental config of docker is false"; \
+		exit 1; \
+	fi

--- a/Makefile.variables
+++ b/Makefile.variables
@@ -38,10 +38,10 @@ BUILD_CMD = go build
 DOCKER_SOCK_PATH=/var/run/docker.sock
 DOCKER_MAKE_CMD = docker run --rm -v ${PROJECT_SOURCE_CODE_DIR}:${BUILDER_MOUNT_DST_DIR} -v ${DOCKER_SOCK_PATH}:${DOCKER_SOCK_PATH} -w ${BUILDER_MOUNT_DST_DIR} -i ${BUILDER_NAME}:${BUILDER_TAG}
 DOCKER_DEBUG_CMD = docker run --rm -v ${PROJECT_SOURCE_CODE_DIR}:${BUILDER_MOUNT_DST_DIR} -v ${DOCKER_SOCK_PATH}:${DOCKER_SOCK_PATH} -w ${BUILDER_MOUNT_DST_DIR} -it ${BUILDER_NAME}:${BUILDER_TAG}
-MUILT_ARCH_PUSH_CMD = ${PROJECT_SOURCE_CODE_DIR}/build/utils/docker-push-with-multi-arch.sh
+MUILT_ARCH_PUSH_CMD = ${PROJECT_SOURCE_CODE_DIR}/build/util/docker-push-with-multi-arch.sh
 
-DOCKER_BUILDX_CMD_AMD64 = DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64 -o type=docker
-DOCKER_BUILDX_CMD_ARM64 = DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/arm64 -o type=docker
+DOCKER_BUILDX_CMD_AMD64 = DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64 -o type=docker --builder mutil-platform-builder
+DOCKER_BUILDX_CMD_ARM64 = DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/arm64 -o type=docker --builder mutil-platform-builder
 
 # [ BUILD/LDM ]
 LDM_BUILD_OUTPUT = ${BINS_DIR}/${LDM_MODULE_NAME}


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Fix image build error when build for arm64 image

#### Special notes for your reviewer:
##### How to do?
**Create and enable mutil-platform-builder** when buildx is disabled or builder is missing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
