### PR TITLE
helm: support claim node disk when helm install

### DIFF
--- a/helm/hwameistor/templates/post-install-claim-disks.yaml
+++ b/helm/hwameistor/templates/post-install-claim-disks.yaml
@@ -1,0 +1,21 @@
+# Claim nodes disks
+{{-  range .Values.storageNodes }}
+{{- $name :=  .  }}
+{{- if not (lookup "hwameistor.io/v1alpha1" "LocalDiskClaim" "" $name ) }}
+apiVersion: hwameistor.io/v1alpha1
+kind: LocalDiskClaim
+metadata:
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-failed
+  name: {{ $name }}
+spec:
+  # nodeName is the node where disk is attached
+  # If nodeName contains ".",please replace it with "-".
+  # The field value should be consistent with the nodeName in localdisk
+  nodeName: {{ . }}
+  description:
+    diskType: {{ $.Values.storageclass.diskType }}
+---
+{{- end}}
+{{- end}}

--- a/helm/hwameistor/values.yaml
+++ b/helm/hwameistor/values.yaml
@@ -21,6 +21,9 @@ storageclass:
   diskType: HDD
   fsType: xfs
 
+# storageNodes means the nodes will be used for creating local volumes
+storageNodes: []
+
 scheduler:
   replicas: 1
   kubeApiServerConfigFilePath: /etc/kubernetes/admin.conf


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Apply LocalDsikClaim after install
#### Special notes for your reviewer:
you can set storagenodes when helm install:
```
helm install hwameistor . --set "storageNodes={<node1>,<node2>}"
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
