### PR TITLE
ldc: reconcile disk request when no disks available

### DIFF
--- a/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim.go
+++ b/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim.go
@@ -2,6 +2,7 @@ package localdiskclaim
 
 import (
 	"context"
+	"fmt"
 
 	ldmv1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/local-disk-manager/v1alpha1"
 	localdisk2 "github.com/hwameistor/hwameistor/pkg/local-disk-manager/handler/localdisk"
@@ -105,7 +106,7 @@ func (ldcHandler *LocalDiskClaimHandler) AssignFreeDisk() error {
 
 	if len(assignedDisks) == 0 {
 		log.Infof("There is no available disk assigned to %v", ldc.GetName())
-		return nil
+		return fmt.Errorf("there is no available disk assigned to %v", ldc.GetName())
 	}
 
 	log.Infof("Disk %v has been assigned to %v", assignedDisks, ldc.GetName())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Reconcile disk request when no disks available.

#### Special notes for your reviewer:
Requeue request interval default is 5 seconds.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
