### PR TITLE
helm: don't lookup namespaced resource when intsall

### DIFF
--- a/helm/hwameistor/templates/local-disk-manager-csi-controller.yaml
+++ b/helm/hwameistor/templates/local-disk-manager-csi-controller.yaml
@@ -1,4 +1,3 @@
-{{- if and ( not (lookup "apps/v1" "Deployment" .Release.Namespace "hwameistor-local-disk-csi-controller") ) .Values.localDiskManager.enableCSI }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -66,4 +65,3 @@ spec:
           hostPath:
             path: {{ template "hwameistor.kubeletRootDir" . }}/plugins/disk.hwameistor.io
             type: DirectoryOrCreate
-{{- end -}}

--- a/helm/hwameistor/templates/local-disk-manager.yaml
+++ b/helm/hwameistor/templates/local-disk-manager.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "apps/v1" "DaemonSet" .Release.Namespace "hwameistor-local-disk-manager") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -140,4 +139,3 @@ spec:
           key: node.cloudprovider.kubernetes.io/uninitialized
           operator: Exists
       {{- end }}
-{{- end }}

--- a/helm/hwameistor/templates/local-storage-csi-controller.yaml
+++ b/helm/hwameistor/templates/local-storage-csi-controller.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "apps/v1" "Deployment" .Release.Namespace "hwameistor-local-storage-csi-controller") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -107,4 +106,3 @@ spec:
           path: {{ template "hwameistor.kubeletRootDir" . }}/plugins/lvm.hwameistor.io
           type: DirectoryOrCreate
         name: socket-dir
-{{- end -}}		

--- a/helm/hwameistor/templates/local-storage.yaml
+++ b/helm/hwameistor/templates/local-storage.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "apps/v1" "DaemonSet" .Release.Namespace "hwameistor-local-storage") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -171,4 +170,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate
-{{- end -}}

--- a/helm/hwameistor/templates/post-install-claim-disks.yaml
+++ b/helm/hwameistor/templates/post-install-claim-disks.yaml
@@ -1,7 +1,6 @@
 # Claim nodes disks
 {{-  range .Values.storageNodes }}
 {{- $name :=  .  }}
-{{- if not (lookup "hwameistor.io/v1alpha1" "LocalDiskClaim" "" $name ) }}
 apiVersion: hwameistor.io/v1alpha1
 kind: LocalDiskClaim
 metadata:
@@ -17,5 +16,4 @@ spec:
   description:
     diskType: {{ $.Values.storageclass.diskType }}
 ---
-{{- end}}
 {{- end}}

--- a/helm/hwameistor/templates/scheduler-config.yaml
+++ b/helm/hwameistor/templates/scheduler-config.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "v1" "ConfigMap" .Release.Namespace "hwameistor-scheduler-config") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -29,4 +28,3 @@ data:
       unreserve:
         enabled:
           - name: hwameistor-scheduler-plugin
-{{- end }}

--- a/helm/hwameistor/templates/scheduler.yaml
+++ b/helm/hwameistor/templates/scheduler.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "apps/v1" "Deployment" .Release.Namespace "hwameistor-scheduler") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,4 +70,3 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
-{{- end -}}		

--- a/helm/hwameistor/templates/serviceaccount.yaml
+++ b/helm/hwameistor/templates/serviceaccount.yaml
@@ -1,8 +1,6 @@
 {{- $serviceAccountName := "hwameistor-admin"}}
-{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace $serviceAccountName) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $serviceAccountName}}
   namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/helm/hwameistor/templates/webhook.yaml
+++ b/helm/hwameistor/templates/webhook.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "apps/v1" "Deployment" .Release.Namespace "hwameistor-webhook") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,10 +56,8 @@ spec:
       volumes:
        - name: webhook-tls-certs
          emptyDir: {}
- {{ end }}
 
 ---
-{{- if not (lookup "apps/v1" "Service" .Release.Namespace "hwameistor-webhook") -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -72,4 +69,3 @@ spec:
   ports:
     - port: 443
       targetPort: webhook-api
-  {{- end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Improve  the process of helm upgrade, more info see: https://github.com/hwameistor/hwameistor/issues/117

#### Special notes for your reviewer:
* This PR only improves the process of helm upgrade and **avoids the problem of deleting pod**.
* There are two cluster level resources(**clusterrole, clusterrolebinding**) that retain the lookup judgment.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
