### PR TITLE
fix invalid kubectl get lsn [...] in NOTES.txt

### DIFF
--- a/helm/hwameistor/templates/NOTES.txt
+++ b/helm/hwameistor/templates/NOTES.txt
@@ -11,7 +11,7 @@ You can use hwameistor to provide LVM volume:
 
   1. Check each storageNode's storage capacity 
   
-     $ kubectl get lsn {{ .Values.storageNodes }} -o jsonpath='{.status.pools.LocalStorage_PoolHDD.freeCapacityBytes}'
+     $ kubectl get lsn -o jsonpath='{.items[*].status.pools.LocalStorage_PoolHDD.freeCapacityBytes}'
   
   2. Create a PVC and specify 'hwameistor-storage-lvm-{{ .Values.storageClass.diskType | lower}}' in pvc.spec.storageClassName
   


### PR DESCRIPTION
example, below is invalid kubectl command:

```
kubectl get lsn [g-master1] -o jsonpath='{.status.pools.LocalStorage_PoolHDD.freeCapacityBytes}'
```

error : `Error from server (NotFound): localstoragenodes.hwameistor.io "[g-master1]" not found`

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
