### PR TITLE
[helm][admission]: add image version option in helm 

### DIFF
--- a/helm/hwameistor/templates/admission-controller.yaml
+++ b/helm/hwameistor/templates/admission-controller.yaml
@@ -19,9 +19,9 @@ spec:
     spec:
       serviceAccountName: hwameistor-admin
       initContainers:
-        - image: ghcr.io/hwameistor/self-signed:v1
-          imagePullPolicy: Always
-          name: admission-controller-init
+        - image:  {{ .Values.hwameistorImageRegistry}}/{{ .Values.admission.selfSigned.imageRepository}}:{{ .Values.admission.selfSigned.tag}}
+          imagePullPolicy: IfNotPresent
+          name: self-signed
           resources:
             {{- toYaml .Values.admission.resources | nindent 12 }}
           env:

--- a/helm/hwameistor/values.yaml
+++ b/helm/hwameistor/values.yaml
@@ -37,6 +37,10 @@ admission:
   replicas: 1
   imageRepository: hwameistor/admission
   resources: {}
+  # self-signed is a tool image for generating self-signed certs used by api-server
+  selfSigned:
+    imageRepository: hwameistor/self-signed
+    tag: v1
 
 localDiskManager:
   tolerationsOnMaster: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Add admission image option in hem. 

Relevant issue: https://github.com/hwameistor/hwameistor/issues/190

#### Special notes for your reviewer:
##### What's changed?
1. Add selfSigned field in admission
2. Adjust imagePullPolicy of selfSigned image to `IfNotPresent`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
