### PR TITLE
improve: check if TargetPath has already mounted

### DIFF
--- a/pkg/local-storage/member/csi/node.go
+++ b/pkg/local-storage/member/csi/node.go
@@ -2,7 +2,6 @@ package csi
 
 import (
 	"fmt"
-
 	localapis "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/local-storage"
 	apisv1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/local-storage/v1alpha1"
 
@@ -95,6 +94,16 @@ func (p *plugin) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	have to allow multiple mounts per node
 	in order to support Pod rolling upgrade
 	*/
+
+	// return directly if device has already mounted at TargetPath
+	if isStringInArray(req.GetTargetPath(), p.mounter.GetDeviceMountPoints(devicePath)) {
+		p.logger.WithFields(log.Fields{
+			"volume":     req.VolumeId,
+			"targetPath": req.TargetPath,
+			"devicePath": devicePath,
+		}).Debug("device has already mounted at target path")
+		return resp, nil
+	}
 
 	if req.GetVolumeCapability().GetBlock() != nil {
 		// raw block


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Verify **whether the mount point already exists**. If it exists, return it directly to ensure the idempotency of the interface.

More err info, see https://github.com/hwameistor/hwameistor/issues/193
#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
