### PR TITLE
fix: ignore not exist error when delete config

### DIFF
--- a/pkg/local-storage/member/node/configer/drbd.go
+++ b/pkg/local-storage/member/node/configer/drbd.go
@@ -416,6 +416,11 @@ func (m *drbdConfigure) DeleteConfig(replica *apisv1alpha1.LocalVolumeReplica) e
 		}
 	}
 
+	// remove symblink
+	if err = os.Remove(replica.Status.DevicePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove symbolic path %s err: %s", replica.Status.DevicePath, err)
+	}
+
 	// remove config file
 	if err = removeResourceConfigFile(resourceName); err != nil {
 		return fmt.Errorf("remove replica %s config file err: %s", replica.Name, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
ignore not exist error when delete config
#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
