### PR TITLE
[helm] changed drbd-adapter charts to use ghcr.io registry

### DIFF
--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -4,3 +4,7 @@ sidebar_label: "Overview"
 ---
 
 # Overview
+
+Hwameistor is an HA local storage system for cloud-native stateful workloads.
+
+![System architecture](../img/architecture.png)

--- a/docs/docs/quick_start/create_stateful/basic/ha.md
+++ b/docs/docs/quick_start/create_stateful/basic/ha.md
@@ -20,7 +20,7 @@ The yaml file for MySQL is borrowed from [the official Repo of Kubernetes](https
 ```console
 $ kubectl apply -f examples/sc_ha.yaml
 
-$ kubectl get sc hwameistor-storage-lvm-hdd -o yaml
+$ kubectl get sc hwameistor-storage-lvm-hdd-ha -o yaml
 
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -64,15 +64,6 @@ spec:
       resources:
         requests:
           storage: 1Gi
-```
-
-and `schedulerName: hwameistor-scheduler`:
-
-```yaml
-spec:
-  template:
-    spec:
-      schedulerName: hwameistor-scheduler
 ```
 
 ## Verify MySQL Pod and `PVC/PV`

--- a/docs/docs/quick_start/install/deploy.md
+++ b/docs/docs/quick_start/install/deploy.md
@@ -97,9 +97,9 @@ In a resource-strained test environment, setting the above-mentioned values woul
 
 To enable provisioning HA volumes, DRBD must be installed:
 
-```console 
-$ helm pull hwameistor/drbd9-adapter --untar
+```console
+$ helm pull hwameistor/drbd-adapter --untar
 
-$ helm install drbd9 ./drbd9-adapter \
+$ helm install drbd-adapter ./drbd-adapter \
     -n hwameistor --create-namespace
 ```

--- a/docs/docs/what.md
+++ b/docs/docs/what.md
@@ -17,3 +17,21 @@ HwameiStor is an open source, lightweight, and cost-efficient local storage syst
  By using the CAS pattern, users can achieve the benefits of higher performance, better cost-efficiency, and easier management for their container storage. It can be deployed by helm charts or directly use the independent installation. You can easily enable the high-performance local storage across entire cluster with one click and automatically identify disks.
 
 HwameiStor is easy to deploy and ready to go.
+
+## Features
+
+1. Automated Maintenance
+
+    Disks can be automatically discovered, identified, managed, and allocated. Smart scheduling of applications and data based on affinity. Automatically monitor disk status and give early warning.
+
+1. High Availability
+
+    Use cross-node replicas to synchronize data for high availability. When a problem occurs, the application will be automatically scheduled to the high-availability data node to ensure the continuity of the application.
+
+1. Full-Range support of Storage Medium
+
+   Aggregate HDD, SSD, and NVMe disks to provide low-latency, high-throughput data services.
+
+1. Agile Linear Scalability
+
+   Dynamically expand the cluster according to flexibly meet the data persistence requirements of the application.

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/architecture/overview.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/architecture/overview.md
@@ -4,3 +4,7 @@ sidebar_label: "概览"
 ---
 
 # 概览
+
+Hwameistor 是一个高可用的本地云原生存储
+
+![System architecture](../img/architecture.png)

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/create_stateful/basic/ha.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/create_stateful/basic/ha.md
@@ -20,7 +20,7 @@ HwameiStor 使用开源的 DRBD 数据同步技术创建 **高可用卷**，又�
 ```console
 $ kubectl apply -f examples/sc_ha.yaml
 
-$ kubectl get sc hwameistor-storage-lvm-hdd -o yaml
+$ kubectl get sc hwameistor-storage-lvm-hdd-ha -o yaml
 
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -64,15 +64,6 @@ spec:
       resources:
         requests:
           storage: 1Gi
-```
-
-和 `schedulerName: hwameistor-scheduler`:
-
-```yaml
-spec:
-  template:
-    spec:
-      schedulerName: hwameistor-scheduler
 ```
 
 ## 查看 MySQL Pod and `PVC/PV`

--- a/helm/drbd-adapter/templates/drbd-adapter.yaml
+++ b/helm/drbd-adapter/templates/drbd-adapter.yaml
@@ -1,28 +1,29 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: drbd9-adapter
+  name: drbd-adapter
   labels:
-    k8s-app: drbd9-adapter
+    k8s-app: drbd-adapter
 spec:
   selector:
     matchLabels:
-      name: drbd9-adapter
+      k8s-app: drbd-adapter
   template:
     metadata:
       labels:
-        name: drbd9-adapter
+        k8s-app: drbd-adapter
     spec:
       initContainers:
       - name: shipper
-        image: daocloud.io/daocloud/drbd9-shipper:v9.1.8
-        imagePullPolicy: IfNotPresent
+        image: {{ .Values.registry}}/drbd9-shipper:{{ .Values.drbdVersion}}
+        imagePullPolicy: Always
         volumeMounts:
         - name: pkgs
           mountPath: /pkgs
-      - name: drbd9-rhel7
-        image: daocloud.io/daocloud/drbd9-rhel7:v9.1.8
-        imagePullPolicy: IfNotPresent
+
+      - name: rhel7
+        image: {{ .Values.registry}}/drbd9-rhel7:{{ .Values.drbdVersion}}
+        imagePullPolicy: Always
         command: [ /pkgs/entrypoint.adapter.sh ]
         securityContext:
           privileged: true
@@ -44,13 +45,13 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
         - name: usr-local-bin
-          mountPath: /usr/local/bin
+          mountPath: /usr-local-bin
         - name: etc-modules-load
           mountPath: /etc/modules-load.d
 
-      - name: drbd9-rhel8
-        image: daocloud.io/daocloud/drbd9-rhel8:v9.1.8
-        imagePullPolicy: IfNotPresent
+      - name: rhel8
+        image: {{ .Values.registry}}/drbd9-rhel8:{{ .Values.drbdVersion}}
+        imagePullPolicy: Always
         command: [ /pkgs/entrypoint.adapter.sh ]
         securityContext:
           privileged: true
@@ -72,13 +73,13 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
         - name: usr-local-bin
-          mountPath: /usr/local/bin
+          mountPath: /usr-local-bin
         - name: etc-modules-load
           mountPath: /etc/modules-load.d
 
-      - name: drbd9-bionic
-        image: daocloud.io/daocloud/drbd9-bionic:v9.1.8
-        imagePullPolicy: IfNotPresent
+      - name: bionic
+        image: {{ .Values.registry}}/drbd9-bionic:{{ .Values.drbdVersion}}
+        imagePullPolicy: Always
         command: [ /pkgs/entrypoint.adapter.sh ]
         securityContext:
           privileged: true
@@ -97,13 +98,13 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
         - name: usr-local-bin
-          mountPath: /usr/local/bin
+          mountPath: /usr-local-bin
         - name: etc-modules-load
           mountPath: /etc/modules-load.d
 
-      - name: drbd9-focal
-        image: daocloud.io/daocloud/drbd9-focal:v9.1.8
-        imagePullPolicy: IfNotPresent
+      - name: focal
+        image: {{ .Values.registry}}/drbd9-focal:{{ .Values.drbdVersion}}
+        imagePullPolicy: Always
         command: [ /pkgs/entrypoint.adapter.sh ]
         securityContext:
           privileged: true
@@ -122,13 +123,13 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
         - name: usr-local-bin
-          mountPath: /usr/local/bin
+          mountPath: /usr-local-bin
         - name: etc-modules-load
           mountPath: /etc/modules-load.d
 
-      - name: drbd9-jammy
-        image: daocloud.io/daocloud/drbd9-jammy:v9.1.8
-        imagePullPolicy: IfNotPresent
+      - name: jammy
+        image: {{ .Values.registry}}/drbd9-jammy:{{ .Values.drbdVersion}}
+        imagePullPolicy: Always
         command: [ /pkgs/entrypoint.adapter.sh ]
         securityContext:
           privileged: true
@@ -147,18 +148,18 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
         - name: usr-local-bin
-          mountPath: /usr/local/bin
+          mountPath: /usr-local-bin
         - name: etc-modules-load
           mountPath: /etc/modules-load.d
 
       containers:
       - name: monitor
-        image: daocloud.io/daocloud/drbd-reactor
+        image: quay.io/piraeusdatastore/drbd-reactor
         imagePullPolicy: IfNotPresent
         command:
-        - drbd-reactor 
-        - -c
-        - /pkgs/drbd-reactor.toml
+        - tail
+        - -f
+        - /dev/null
         volumeMounts:
         - name: pkgs
           mountPath: /pkgs
@@ -186,6 +187,7 @@ spec:
       - name: etc-modules-load
         hostPath:
           path: /etc/modules-load.d
+
       affinity:
         nodeAffinity:
 		 {{- toYaml .Values.affinity.nodeAffinity | nindent 10 }}

--- a/helm/drbd-adapter/values.yaml
+++ b/helm/drbd-adapter/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+registry: ghcr.io/hwameistor
+
+drbdVersion: v9.1.8
+
 nodeSelector: {}
 
 tolerations: []
@@ -11,7 +15,5 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
       - matchExpressions:
-        - key: lvm.hwameistor.io/enable
-          operator: NotIn
-          values:
-            - "false"
+        - key: node-role.kubernetes.io/master
+          operator: DoesNotExist


### PR DESCRIPTION
As suggested by @yankay, change drbd-adapter helm charts to use `ghcr.io` registry instead of daocloud.io. 

Other changes 

1. removed `schedulerName` setup from the guide as it is no longer needed;
2. correct the mount path for `/usr/local/bin`;
3. suspends `drbd-reactor` process because it often gives no log;
4. correct some typos in the doc;
