### PR TITLE
采用 preferredDuringSchedulingIgnoredDuringExecution 优化 hwameistor-scheduler 调度逻辑

### DIFF
--- a/helm/hwameistor/templates/scheduler.yaml
+++ b/helm/hwameistor/templates/scheduler.yaml
@@ -15,13 +15,13 @@ spec:
       labels:
         app: hwameistor-scheduler
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
       containers:
       - args:
         - -v=2


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
当 Kubernetes node 没有   node-role.kubernetes.io/master 标签时（如 microk8s），  hwameistor-scheduler 无法完成调度

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
采用 preferredDuringSchedulingIgnoredDuringExecution 的逻辑调度 hwameistor-scheduler，兼容没有 node-role.kubernetes.io/master 的场景
```
