### PR TITLE
fix: syntax error in getResourceDiskState

### DIFF
--- a/pkg/local-storage/member/node/configer/drbd.go
+++ b/pkg/local-storage/member/node/configer/drbd.go
@@ -371,11 +371,12 @@ func (m *drbdConfigure) getResourceDiskState(resourceName string) (state string,
 	}
 	result := m.cmdExec.RunCommand(params)
 	if result.ExitCode != 0 {
-		return "", fmt.Errorf("get resource %s disk state err: %d, %s", resourceName, result.ExitCode, result.ErrBuf.String())
+		err = fmt.Errorf("get resource %s disk state err: %d, %s", resourceName, result.ExitCode, result.ErrBuf.String())
+		return
 	}
 	// there may be peers disk state
 	state = strings.SplitN(result.OutBuf.String(), "/", 2)[0]
-	return state, nil
+	return
 }
 
 // resizeResource is idempotent


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
fix: syntax error in getResourceDiskState

relvent issue: https://github.com/hwameistor/hwameistor/issues/295
#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
