### PR TITLE
fix: return directly when publish node is empty

### DIFF
--- a/pkg/local-storage/member/csi/controller.go
+++ b/pkg/local-storage/member/csi/controller.go
@@ -476,6 +476,13 @@ func (p *plugin) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 		return resp, err
 	}
 
+	// when publish node is empty, return directly
+	// https://github.com/hwameistor/hwameistor/issues/296
+	if vol.Status.PublishedNodeName == "" {
+		p.logger.WithFields(log.Fields{"volume": req.VolumeId, "node": req.NodeId}).Debug("Volume has already unpublished")
+		return resp, nil
+	}
+
 	if vol.Status.PublishedNodeName != req.NodeId {
 		p.logger.WithFields(log.Fields{"volume": req.VolumeId, "node": req.NodeId}).Error("Wrong published node in request")
 		return resp, fmt.Errorf("wrong published node")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Volume can't be recycled when publish node in LVR is empty.

More error see: #252 #296 
#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
