### PR TITLE
[Docs] Clarify that "secure boot" is not yet supported"

### DIFF
--- a/docs/docs/quick_start/install/deploy.md
+++ b/docs/docs/quick_start/install/deploy.md
@@ -97,6 +97,10 @@ In a resource-strained test environment, setting the above-mentioned values woul
 
 To enable provisioning HA volumes, DRBD must be installed:
 
+:::caution
+Please refer to [**Prerequisites**](./prereq.md) for environmental requirements.
+:::
+
 ```console
 $ helm pull hwameistor/drbd-adapter --untar
 

--- a/docs/docs/quick_start/install/prereq.md
+++ b/docs/docs/quick_start/install/prereq.md
@@ -48,6 +48,18 @@ $ apt-get install -y lvm2
 $ apt-get install -y linux-headers-$(uname -r)
 ```
 
+### Secure Boot
+
+The HA feature does not yet support `Secure Boot`. Make sure `Secure Boot` is `disabled`：
+
+```console
+$ mokutil --sb-state
+SecureBoot disabled
+
+$ dmesg | grep secureboot
+[    0.000000] secureboot: Secure boot disabled
+```
+
 ### Data Disk
 
 HwameiStor supports `HDD`, `SSD` and `NVMe`.

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/install/deploy.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/install/deploy.md
@@ -96,7 +96,11 @@ $ helm install hwameistor ./hwameistor \
 
 ## [可选] 安装 DRBD
 
-如果要启用高可用卷, 必须安装 DRBD
+如果要启用高可用卷, 必须安装 DRBD:
+
+:::caution
+请注意 [**准备工作**](./prereq.md) 里的环境要求
+:::
 
 ```console
 $ helm pull hwameistor/drbd9-adapter --untar

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/install/prereq.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/install/prereq.md
@@ -48,6 +48,18 @@ $ apt-get install -y lvm2
 $ apt-get install -y linux-headers-$(uname -r)
 ```
 
+### Secure Boot
+
+高可用功能暂时不支持 `Secure Boot`, 确认 `Secure Boot` 是 `disabled` 状态：
+
+```console
+$ mokutil --sb-state
+SecureBoot disabled
+
+$ dmesg | grep secureboot
+[    0.000000] secureboot: Secure boot disabled
+```
+
 ### 数据盘
 
 HwameiStor 支持物理硬盘(HDD)、固态硬盘(SSD) 和 NVMe 闪存盘.


### PR DESCRIPTION
Signed-off-by: alexzhc <alex.zheng@daocloud.io>

Add clarification to `Quick Start` that `secure boot` is not yet supported and needs to be `disabled` for now.  