### PR TITLE
fix: Lower case storageclass.kubernetes.io in annotations

### DIFF
--- a/helm/hwameistor/templates/storageclass.yaml
+++ b/helm/hwameistor/templates/storageclass.yaml
@@ -11,7 +11,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageClass.kubernetes.io/is-default-class: {{ .Values.storageClass.default | quote }}
+    storageclass.kubernetes.io/is-default-class: {{ .Values.storageClass.default | quote }}
   name: hwameistor-storage-lvm-{{ .Values.storageClass.diskType | lower}}
 provisioner: lvm.hwameistor.io
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Lower case storageclass.kubernetes.io in annotations to enable default storageclass or not

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
