### PR TITLE
fix: check if disk has already bound with the claim

### DIFF
--- a/pkg/local-disk-manager/filter/filter_disk.go
+++ b/pkg/local-disk-manager/filter/filter_disk.go
@@ -110,6 +110,18 @@ func (ld *LocalDiskFilter) NoPartition() *LocalDiskFilter {
 	return ld
 }
 
+// HasBoundWith indicates disk has already bound with the claim
+// https://github.com/hwameistor/hwameistor/issues/315
+func (ld *LocalDiskFilter) HasBoundWith(claimName string) bool {
+	if ld.LocalDisk.Spec.ClaimRef != nil {
+		if ld.LocalDisk.Spec.ClaimRef.Name == claimName {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Capacity
 func (ld *LocalDiskFilter) GetTotalResult() bool {
 	return ld.Result == TRUE

--- a/pkg/local-disk-manager/handler/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk.go
@@ -141,6 +141,12 @@ func (ldHandler *LocalDiskHandler) ClaimRef() *v1.ObjectReference {
 
 // FilterDisk
 func (ldHandler *LocalDiskHandler) FilterDisk(ldc ldm.LocalDiskClaim) bool {
+	// Bounded disk
+	if ldHandler.filter.HasBoundWith(ldc.GetName()) {
+		return true
+	}
+
+	// Unbound disk
 	return ldHandler.filter.
 		Init().
 		Unclaimed().

--- a/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim.go
+++ b/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim.go
@@ -140,7 +140,17 @@ func (ldcHandler *LocalDiskClaimHandler) BoundWith(ld ldmv1alpha1.LocalDisk) err
 		return err
 	}
 
-	ldcHandler.ldc.Spec.DiskRefs = append(ldcHandler.ldc.Spec.DiskRefs, ldRef)
+	// check if this disk has already bound
+	needBound := true
+	for _, boundDisk := range ldcHandler.ldc.Spec.DiskRefs {
+		if boundDisk.Name == ld.GetName() {
+			needBound = false
+		}
+	}
+	if needBound {
+		ldcHandler.ldc.Spec.DiskRefs = append(ldcHandler.ldc.Spec.DiskRefs, ldRef)
+	}
+
 	ldcHandler.ldc.Status.Status = ldmv1alpha1.LocalDiskClaimStatusBound
 
 	ldcHandler.EventRecorder.Eventf(&ldcHandler.ldc, v1.EventTypeNormal, "BoundLocalDisk", "Bound disk %v", ld.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
fix #315 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
