### PR TITLE
fix: only set extend flag when extend disks not empty

### DIFF
--- a/pkg/local-storage/member/node/storage/executor_lvm.go
+++ b/pkg/local-storage/member/node/storage/executor_lvm.go
@@ -406,6 +406,9 @@ func (lvm *lvmExecutor) ExtendPools(availableLocalDisks []*apisv1alpha1.LocalDis
 	}
 
 	for poolName, classifiedDisks := range disksToBeExtends {
+		if len(classifiedDisks) == 0 {
+			continue
+		}
 		if err := lvm.extendPool(poolName, classifiedDisks); err != nil {
 			lvm.logger.WithError(err).Error("Add available disk failed.")
 			return extend, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Don't record events when no disks to be extended.

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
