### PR TITLE
fixed some bugs in evictor

### DIFF
--- a/pkg/evictor/evict.go
+++ b/pkg/evictor/evict.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -12,18 +11,17 @@ import (
 	localstorageclientset "github.com/hwameistor/hwameistor/pkg/apis/client/clientset/versioned"
 	localstorageinformers "github.com/hwameistor/hwameistor/pkg/apis/client/informers/externalversions"
 	localstorageinformersv1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/client/informers/externalversions/hwameistor/v1alpha1"
-	localstoragelisters "github.com/hwameistor/hwameistor/pkg/apis/client/listers/hwameistor/v1alpha1"
 	localstorageapis "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
-	"github.com/hwameistor/hwameistor/pkg/common"
+	"github.com/hwameistor/hwameistor/pkg/local-storage/common"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	informercorev1 "k8s.io/client-go/informers/core/v1"
+	informerstoragev1 "k8s.io/client-go/informers/storage/v1"
+
 	"k8s.io/client-go/kubernetes"
-	corev1lister "k8s.io/client-go/listers/core/v1"
-	storagev1lister "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -43,16 +41,15 @@ type evictor struct {
 	clientset *kubernetes.Clientset
 
 	podInformer informercorev1.PodInformer
-	pvcLister   corev1lister.PersistentVolumeClaimLister
-	pvLister    corev1lister.PersistentVolumeLister
-	scLister    storagev1lister.StorageClassLister
+	pvcInformer informercorev1.PersistentVolumeClaimInformer
+	scInformer  informerstoragev1.StorageClassInformer
 
 	lsClientset       *localstorageclientset.Clientset
-	lvLister          localstoragelisters.LocalVolumeLister
+	lvInformer        localstorageinformersv1alpha1.LocalVolumeInformer
 	lvMigrateInformer localstorageinformersv1alpha1.LocalVolumeMigrateInformer
 
-	evictedPodQueue    common.TaskQueue
-	migrateVolumeQueue common.TaskQueue
+	evictedPodQueue    *common.TaskQueue
+	migrateVolumeQueue *common.TaskQueue
 }
 
 /* steps:
@@ -65,31 +62,27 @@ type evictor struct {
 func New(clientset *kubernetes.Clientset) Evictor {
 	return &evictor{
 		clientset:          clientset,
-		evictedPodQueue:    *common.NewTaskQueue("EvictedPods", 0),
-		migrateVolumeQueue: *common.NewTaskQueue("MigrateVolumes", 0),
+		evictedPodQueue:    common.NewTaskQueue("EvictedPods", 0),
+		migrateVolumeQueue: common.NewTaskQueue("MigrateVolumes", 0),
 	}
 }
 
 func (ev *evictor) Run(stopCh <-chan struct{}) error {
+	log.Debug("start informer factory")
 	factory := informers.NewSharedInformerFactory(ev.clientset, 0)
+	factory.Start(stopCh)
 
 	ev.podInformer = factory.Core().V1().Pods()
 	ev.podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: ev.watchForEvictedPod,
+		UpdateFunc: ev.watchForEvictedPodOnUpdate,
+		DeleteFunc: ev.watchForEvictedPodOnDelete,
 	})
+	go ev.podInformer.Informer().Run(stopCh)
 
-	ev.pvcLister = factory.Core().V1().PersistentVolumeClaims().Lister()
-	ev.pvLister = factory.Core().V1().PersistentVolumes().Lister()
-	ev.scLister = factory.Storage().V1().StorageClasses().Lister()
-
-	log.Debug("start informer factory")
-	factory.Start(stopCh)
-	for _, v := range factory.WaitForCacheSync(stopCh) {
-		if !v {
-			log.Error("Timed out waiting for cache to sync")
-			return fmt.Errorf("timed out waiting for cache to sync")
-		}
-	}
+	ev.pvcInformer = factory.Core().V1().PersistentVolumeClaims()
+	go ev.pvcInformer.Informer().Run(stopCh)
+	ev.scInformer = factory.Storage().V1().StorageClasses()
+	go ev.scInformer.Informer().Run(stopCh)
 
 	// Initialize HwameiStor LocalStorage resources
 	// Get a config to talk to the apiserver
@@ -98,9 +91,13 @@ func (ev *evictor) Run(stopCh <-chan struct{}) error {
 		log.WithError(err).Fatal("Failed to get kubernetes cluster config")
 	}
 
+	log.Debug("start local storage informer factory")
 	ev.lsClientset = localstorageclientset.NewForConfigOrDie(cfg)
 	lsFactory := localstorageinformers.NewSharedInformerFactory(ev.lsClientset, 0)
-	ev.lvLister = lsFactory.Hwameistor().V1alpha1().LocalVolumes().Lister()
+	lsFactory.Start(stopCh)
+
+	ev.lvInformer = lsFactory.Hwameistor().V1alpha1().LocalVolumes()
+	go ev.lvInformer.Informer().Run(stopCh)
 
 	// index: lvmigrate.spec.volumename
 	lvMigrateVolumeNameIndexFunc := func(obj interface{}) ([]string, error) {
@@ -112,79 +109,70 @@ func (ev *evictor) Run(stopCh <-chan struct{}) error {
 	}
 	ev.lvMigrateInformer = lsFactory.Hwameistor().V1alpha1().LocalVolumeMigrates()
 	ev.lvMigrateInformer.Informer().AddIndexers(cache.Indexers{localVolumeNameIndex: lvMigrateVolumeNameIndexFunc})
-
-	log.Debug("start local storage informer factory")
-	lsFactory.Start(stopCh)
-	for _, v := range lsFactory.WaitForCacheSync(stopCh) {
-		if !v {
-			log.Error("Timed out waiting for local storage cache to sync")
-			return fmt.Errorf("timed out waiting for local storage cache to sync")
-		}
-	}
+	go ev.lvMigrateInformer.Informer().Run(stopCh)
 
 	log.Debug("starting migrate volume worker")
 	go ev.startMigrateVolumeWorker(stopCh)
 
-	log.Debug("starting evicted pod worker")
-	go ev.startEvictedPodWorker(stopCh)
-
+	<-stopCh
 	return nil
 }
 
-func (ev *evictor) watchForEvictedPod(oObj, nObj interface{}) {
+func (ev *evictor) watchForEvictedPodOnUpdate(oObj, nObj interface{}) {
 	pod, _ := nObj.(*corev1.Pod)
-	if strings.Contains(pod.Status.Reason, "Evicted") {
+	log.WithFields(log.Fields{
+		"namespace": pod.Namespace,
+		"pod":       pod.Name,
+		"message":   pod.Status.Conditions[0].Type,
+		"reason":    pod.Status.Reason,
+		"phase":     pod.Status.Phase,
+	}).Debug("Watching for a Pod update event ...")
+	if isPodEvicted(pod) {
 		log.WithFields(log.Fields{
 			"namespace": pod.Namespace,
 			"pod":       pod.Name,
 			"phase":     pod.Status.Phase,
 			"reason":    pod.Status.Reason,
 		}).Debug("Got an evicted Pod to process")
-		ev.evictedPodQueue.Add(getNamespacedName(pod.Namespace, pod.Name))
+		go ev.filterForHwameiVolume(pod)
 	}
 }
 
-func (ev *evictor) startEvictedPodWorker(stopCh <-chan struct{}) {
-
-	log.Debug("Evict Worker is working now")
-	go func() {
-		for {
-			time.Sleep(15 * time.Second)
-			task, shutdown := ev.evictedPodQueue.Get()
-			if shutdown {
-				log.WithFields(log.Fields{"task": task}).Debug("Stop the Evicted Pod worker")
-				break
-			}
-			if err := ev.processEvictedPod(task); err != nil {
-				log.WithFields(log.Fields{"task": task, "error": err.Error()}).Error("Failed to process Evicted Pod, retry later")
-				ev.evictedPodQueue.AddRateLimited(task)
-			} else {
-				log.WithFields(log.Fields{"task": task}).Debug("Completed a task for Evicted Pod.")
-				ev.evictedPodQueue.Forget(task)
-			}
-			ev.evictedPodQueue.Done(task)
-		}
-	}()
-
-	<-stopCh
-	ev.evictedPodQueue.Shutdown()
+func (ev *evictor) watchForEvictedPodOnDelete(obj interface{}) {
+	pod, _ := obj.(*corev1.Pod)
+	log.WithFields(log.Fields{
+		"namespace": pod.Namespace,
+		"pod":       pod.Name,
+		"message":   pod.Status.Conditions[0].Type,
+		"reason":    pod.Status.Reason,
+		"phase":     pod.Status.Phase,
+	}).Debug("Watching for a Pod delete event ...")
+	if isPodEvicted(pod) {
+		log.WithFields(log.Fields{
+			"namespace": pod.Namespace,
+			"pod":       pod.Name,
+			"phase":     pod.Status.Phase,
+			"reason":    pod.Status.Reason,
+		}).Debug("Got an evicted Pod to process")
+		go ev.filterForHwameiVolume(pod)
+	}
 }
 
-func (ev *evictor) processEvictedPod(namespacedName string) error {
-	logCtx := log.WithField("pod", namespacedName)
+func isPodEvicted(pod *corev1.Pod) bool {
+	return true
+	// podFailed := pod.Status.Phase == corev1.PodFailed
+	// podEvicted := pod.Status.Reason == "Evicted"
+	// return podFailed && podEvicted
+}
+
+func (ev *evictor) filterForHwameiVolume(pod *corev1.Pod) error {
+	logCtx := log.WithFields(log.Fields{"pod": pod.Name, "namespace": pod.Namespace})
 	logCtx.Debug("Start to process an evicted pod")
-
-	podNamespace, podName := parseNamespacedName(namespacedName)
-	pod, err := ev.podInformer.Lister().Pods(podNamespace).Get(podName)
-	if err != nil {
-		logCtx.WithError(err).Error("Failed to get the pod from the cluster")
-		return err
-	}
 	for _, vol := range pod.Spec.Volumes {
 		if vol.PersistentVolumeClaim == nil {
 			continue
 		}
-		pvc, err := ev.pvcLister.PersistentVolumeClaims(pod.Namespace).Get(vol.PersistentVolumeClaim.ClaimName)
+		pvc, err := ev.pvcInformer.Lister().PersistentVolumeClaims(pod.Namespace).Get(vol.PersistentVolumeClaim.ClaimName)
 		if err != nil {
 			// if pvc can't be found in the cluster, the pod should not be able to be scheduled
 			logCtx.WithFields(log.Fields{
@@ -197,7 +185,7 @@ func (ev *evictor) processEvictedPod(namespacedName string) error {
 			// should not be the CSI pvc, ignore
 			continue
 		}
-		sc, err := ev.scLister.Get(*pvc.Spec.StorageClassName)
+		sc, err := ev.scInformer.Lister().Get(*pvc.Spec.StorageClassName)
 		if err != nil {
 			// can't found storageclass in the cluster, the pod should not be able to be scheduled
 			logCtx.WithFields(log.Fields{
@@ -225,7 +213,6 @@ func (ev *evictor) startMigrateVolumeWorker(stopCh <-chan struct{}) {
 	log.Debug("Migrate Volume Worker is working now")
 	go func() {
 		for {
-			time.Sleep(15 * time.Second)
 			task, shutdown := ev.migrateVolumeQueue.Get()
 			if shutdown {
 				log.WithFields(log.Fields{"task": task}).Debug("Stop the Migrate Volume worker")
@@ -251,7 +238,7 @@ func (ev *evictor) evictVolume(migrateTask string) error {
 	logCtx.Debug("Start to process an local volume migrate task")
 
 	lvName, nodeName := parseMigrateVolumeTask(migrateTask)
-	lv, err := ev.lvLister.Get(lvName)
+	lv, err := ev.lvInformer.Lister().Get(lvName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logCtx.Debug("Not found the LocalVolume in the system, ignore it")
@@ -279,15 +266,15 @@ func (ev *evictor) evictVolume(migrateTask string) error {
 				logCtx.Debug("There is no Migrate job running against the LocalVolume, submit a new one")
 				lvm := &localstorageapis.LocalVolumeMigrate{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      lvName,
-						Namespace: lv.Namespace,
+						Name: lvName,
+						//Namespace: "hwameistor",
 					},
 					Spec: localstorageapis.LocalVolumeMigrateSpec{
 						VolumeName:       lvName,
 						SourceNodesNames: []string{nodeName},
 						// don't specify the target nodes, so the scheduler will select from the avaliables
-						//TargetNodesNames: []string{},
-						MigrateAllVols: true,
+						TargetNodesNames: []string{},
+						MigrateAllVols:   true,
 					},
 				}
 				if _, err := ev.lsClientset.HwameistorV1alpha1().LocalVolumeMigrates().Create(context.Background(), lvm, metav1.CreateOptions{}); err != nil {
@@ -313,18 +300,18 @@ func (ev *evictor) evictVolume(migrateTask string) error {
 	return nil
 }
 
-func getNamespacedName(namespace string, name string) string {
-	return fmt.Sprintf("%s/%s", namespace, name)
-}
+// func getNamespacedName(namespace string, name string) string {
+// 	return fmt.Sprintf("%s/%s", namespace, name)
+// }
 
-// output: namespace, name
-func parseNamespacedName(nn string) (string, string) {
-	items := strings.Split(nn, "/")
-	if len(items) < 2 {
-		return items[0], ""
-	}
-	return items[0], items[1]
-}
+// // output: namespace, name
+// func parseNamespacedName(nn string) (string, string) {
+// 	items := strings.Split(nn, "/")
+// 	if len(items) < 2 {
+// 		return items[0], ""
+// 	}
+// 	return items[0], items[1]
+// }
 
 func constructMigrateVolumeTask(lvName string, nodeName string) string {
 	return fmt.Sprintf("%s/%s", lvName, nodeName)


### PR DESCRIPTION
这个PR解决了evictor的一些基本问题。但还有两个遗留问题：

1）如何捕捉pod被evicted事件？目前看起来 kubectl drain node 似乎不能对pod产生evict事件，或者说产生了但是捕捉不
2）localvolumemigrate目前是namespaced，好像使用起来有点问题