### PR TITLE
Support custom failure policy

### DIFF
--- a/helm/hwameistor/templates/admission-controller.yaml
+++ b/helm/hwameistor/templates/admission-controller.yaml
@@ -35,6 +35,8 @@ spec:
               value: hwameistor-admission-controller
             - name: MUTATE_PATH
               value: /mutate
+            - name: FAILURE_POLICY
+              value: {{ .Values.admission.failurePolicy }}
           resources: 
             {{- toYaml .Values.admission.resources | nindent 12 }}
           ports:

--- a/helm/hwameistor/values.yaml
+++ b/helm/hwameistor/values.yaml
@@ -44,6 +44,9 @@ admission:
   replicas: 1
   imageRepository: hwameistor/admission
   resources: {}
+  # failurePolicy defines how unrecognized errors from the admission endpoint
+  # are handled - allowed values are Ignore or Fail. Defaults to Fail.
+  failurePolicy: ""
   # self-signed is a tool image for generating self-signed certs used by api-server
   selfSigned:
     imageRepository: hwameistor/self-signed

--- a/pkg/webhook/config/config.go
+++ b/pkg/webhook/config/config.go
@@ -24,6 +24,7 @@ var (
 	webhookService, _   = os.LookupEnv("WEBHOOK_SERVICE")
 	validatePath, _     = os.LookupEnv("VALIDATE_PATH")
 	mutationPath, _     = os.LookupEnv("MUTATE_PATH")
+	failurePolicy, _    = os.LookupEnv("FAILURE_POLICY")
 	dnsNames            = []string{webhookService, webhookService + "." + webhookNamespace, webhookService + "." + webhookNamespace + "." + "svc"}
 	commonName          = webhookService + "." + webhookNamespace + "." + "svc"
 	excludeNameSpaceKey = "name"
@@ -111,7 +112,15 @@ func CreateAdmissionConfig(caCert *bytes.Buffer) error {
 					},
 				}},
 				FailurePolicy: func() *admissionregistrationv1.FailurePolicyType {
-					pt := admissionregistrationv1.Fail
+					var pt admissionregistrationv1.FailurePolicyType
+					switch failurePolicy {
+					case string(admissionregistrationv1.Fail):
+						pt = admissionregistrationv1.Fail
+					case string(admissionregistrationv1.Ignore):
+						pt = admissionregistrationv1.Ignore
+					default:
+						pt = admissionregistrationv1.Fail
+					}
 					return &pt
 				}(),
 				NamespaceSelector: &metav1.LabelSelector{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Custom fail policy when do webhook failed.
#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
