### PR TITLE
[WIP] convert all the namespaced CRDs to the cluster wide, and make the volume migrate work

### DIFF
--- a/deploy/crds/hwameistor.io_localvolumegroups_crd.yaml
+++ b/deploy/crds/hwameistor.io_localvolumegroups_crd.yaml
@@ -72,6 +72,8 @@ spec:
                       type: string
                     type: array
                 type: object
+              namespace:
+                type: string
               pods:
                 items:
                   type: string

--- a/pkg/apis/hwameistor/v1alpha1/localvolumegroup_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localvolumegroup_types.go
@@ -20,6 +20,8 @@ type LocalVolumeGroupSpec struct {
 	Accessibility AccessibilityTopology `json:"accessibility,omitempty"`
 
 	Pods []string `json:"pods,omitempty"`
+
+	Namespace string `json:"namespace,omitempty"`
 }
 
 type VolumeInfo struct {

--- a/pkg/apis/hwameistor/v1alpha1/types.go
+++ b/pkg/apis/hwameistor/v1alpha1/types.go
@@ -216,8 +216,8 @@ type SystemConfig struct {
 type VolumeGroupManager interface {
 	Init(stopCh <-chan struct{})
 	ReconcileVolumeGroup(volGroup *LocalVolumeGroup)
-	GetLocalVolumeGroupByName(nameSpace, lvgName string) (*LocalVolumeGroup, error)
-	GetLocalVolumeGroupByLocalVolume(nameSpace, lvName string) (*LocalVolumeGroup, error)
+	GetLocalVolumeGroupByName(lvgName string) (*LocalVolumeGroup, error)
+	GetLocalVolumeGroupByLocalVolume(lvName string) (*LocalVolumeGroup, error)
 	GetLocalVolumeGroupByPVC(pvcName string, pvcNamespace string) (*LocalVolumeGroup, error)
 }
 
@@ -226,7 +226,7 @@ type VolumeGroupManager interface {
 // 		need so much more thinking!!!
 
 // VolumeScheduler interface
-////go:generate mockgen -source=types.go -destination=../../../member/controller/scheduler/scheduler_mock.go  -package=scheduler
+// //go:generate mockgen -source=types.go -destination=../../../member/controller/scheduler/scheduler_mock.go  -package=scheduler
 type VolumeScheduler interface {
 	Init()
 	// schedule will schedule all replicas, and generate a valid VolumeConfig

--- a/pkg/evictor/evict.go
+++ b/pkg/evictor/evict.go
@@ -300,19 +300,6 @@ func (ev *evictor) evictVolume(migrateTask string) error {
 	return nil
 }
 
-// func getNamespacedName(namespace string, name string) string {
-// 	return fmt.Sprintf("%s/%s", namespace, name)
-// }
-
-// // output: namespace, name
-// func parseNamespacedName(nn string) (string, string) {
-// 	items := strings.Split(nn, "/")
-// 	if len(items) < 2 {
-// 		return items[0], ""
-// 	}
-// 	return items[0], items[1]
-// }
-
 func constructMigrateVolumeTask(lvName string, nodeName string) string {
 	return fmt.Sprintf("%s/%s", lvName, nodeName)
 }

--- a/pkg/local-storage/controller/localvolumemigrate/localvolumemigrate_controller.go
+++ b/pkg/local-storage/controller/localvolumemigrate/localvolumemigrate_controller.go
@@ -111,7 +111,7 @@ func (r *ReconcileLocalVolumeMigrate) Reconcile(request reconcile.Request) (reco
 	localVolumeGroupName := vol.Spec.VolumeGroup
 
 	lvg := &apisv1alpha1.LocalVolumeGroup{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: instance.Namespace, Name: localVolumeGroupName}, lvg)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: localVolumeGroupName}, lvg)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/local-storage/member/controller/manager.go
+++ b/pkg/local-storage/member/controller/manager.go
@@ -204,12 +204,12 @@ func (m *manager) ReconcileVolumeExpand(expand *apisv1alpha1.LocalVolumeExpand) 
 
 // ReconcileVolumeMigrate reconciles VolumeMigrate CRD for any volume resource change
 func (m *manager) ReconcileVolumeMigrate(migrate *apisv1alpha1.LocalVolumeMigrate) {
-	m.volumeMigrateTaskQueue.Add(migrate.Namespace + "/" + migrate.Name)
+	m.volumeMigrateTaskQueue.Add(migrate.Name)
 }
 
 // ReconcileVolumeConvert reconciles VolumeConvert CRD for any volume resource change
 func (m *manager) ReconcileVolumeConvert(convert *apisv1alpha1.LocalVolumeConvert) {
-	m.volumeConvertTaskQueue.Add(convert.Namespace + "/" + convert.Name)
+	m.volumeConvertTaskQueue.Add(convert.Name)
 }
 
 func (m *manager) handleK8sNodeUpdatedEvent(oldObj, newObj interface{}) {
@@ -270,7 +270,6 @@ func (m *manager) handleVolumeMigrateCRDDeletedEvent(obj interface{}) {
 		// must be deleted by a mistake, rebuild it
 		// TODO: need retry considering the case of creating failure
 		newInstance := &apisv1alpha1.LocalVolumeMigrate{}
-		newInstance.Namespace = instance.Namespace
 		newInstance.Name = instance.Name
 		newInstance.Spec = instance.Spec
 

--- a/pkg/local-storage/member/csi/controller.go
+++ b/pkg/local-storage/member/csi/controller.go
@@ -22,14 +22,14 @@ import (
 
 var _ csi.ControllerServer = (*plugin)(nil)
 
-//ControllerGetCapabilities implementation
+// ControllerGetCapabilities implementation
 func (p *plugin) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 	p.logger.Debug("ControllerGetCapabilities")
 
 	return &csi.ControllerGetCapabilitiesResponse{Capabilities: p.csCaps}, nil
 }
 
-//CreateVolume implementation, idempotent
+// CreateVolume implementation, idempotent
 func (p *plugin) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	if req.VolumeContentSource != nil {
 		if req.VolumeContentSource.GetSnapshot() != nil {
@@ -155,11 +155,11 @@ func (p *plugin) getLocalVolumeGroupOrCreate(req *csi.CreateVolumeRequest, param
 	}
 	lvg = &apisv1alpha1.LocalVolumeGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      genUUID(),
-			Namespace: params.pvcNamespace,
+			Name: genUUID(),
 		},
 		Spec: apisv1alpha1.LocalVolumeGroupSpec{
-			Volumes: []apisv1alpha1.VolumeInfo{},
+			Namespace: params.pvcNamespace,
+			Volumes:   []apisv1alpha1.VolumeInfo{},
 			Accessibility: apisv1alpha1.AccessibilityTopology{
 				Nodes: selectedNodes,
 			},
@@ -183,7 +183,7 @@ func (p *plugin) getLocalVolumeGroupByPVC(pvcNamespace string, pvcName string) (
 		return nil, err
 	}
 	for i, lvg := range lvgList.Items {
-		if lvg.Namespace != pvcNamespace {
+		if lvg.Spec.Namespace != pvcNamespace {
 			continue
 		}
 		for _, vol := range lvg.Spec.Volumes {
@@ -315,7 +315,7 @@ func (p *plugin) cloneVolume(ctx context.Context, req *csi.CreateVolumeRequest) 
 	return &csi.CreateVolumeResponse{}, fmt.Errorf("not implemented")
 }
 
-//ControllerGetVolume implementation, idempotent
+// ControllerGetVolume implementation, idempotent
 func (p *plugin) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	p.logger.WithFields(log.Fields{"volume": req.VolumeId}).Debug("ControllerGetVolume")
 
@@ -372,7 +372,7 @@ func (p *plugin) ControllerGetVolume(ctx context.Context, req *csi.ControllerGet
 	return resp, nil
 }
 
-//DeleteVolume implementation, idempotent
+// DeleteVolume implementation, idempotent
 func (p *plugin) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"volume":  req.VolumeId,
@@ -404,7 +404,7 @@ func (p *plugin) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	return resp, fmt.Errorf("volume in deleting")
 }
 
-//ControllerPublishVolume implementation, idempotent
+// ControllerPublishVolume implementation, idempotent
 func (p *plugin) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"volume":        req.VolumeId,
@@ -460,7 +460,7 @@ func (p *plugin) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	return resp, fmt.Errorf("not found valid volume replica")
 }
 
-//ControllerUnpublishVolume implementation, idempotent
+// ControllerUnpublishVolume implementation, idempotent
 func (p *plugin) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"volume":  req.VolumeId,
@@ -496,7 +496,7 @@ func (p *plugin) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 	return resp, nil
 }
 
-//ValidateVolumeCapabilities implementation
+// ValidateVolumeCapabilities implementation
 func (p *plugin) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"volume":             req.VolumeId,
@@ -528,7 +528,7 @@ func (p *plugin) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 
 }
 
-//ListVolumes implementation, consider the case of multiple pages
+// ListVolumes implementation, consider the case of multiple pages
 func (p *plugin) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"maxEntries": req.MaxEntries,
@@ -601,7 +601,7 @@ func (p *plugin) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (
 	return resp, nil
 }
 
-//GetCapacity implementation
+// GetCapacity implementation
 func (p *plugin) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"volumeCapabilities": req.VolumeCapabilities,
@@ -616,7 +616,7 @@ func (p *plugin) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (
 	return resp, fmt.Errorf("not supported")
 }
 
-//CreateSnapshot implementation, idempotent
+// CreateSnapshot implementation, idempotent
 func (p *plugin) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"name":         req.Name,
@@ -628,7 +628,7 @@ func (p *plugin) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	return nil, fmt.Errorf("not Implemented")
 }
 
-//DeleteSnapshot implementation, idempotent
+// DeleteSnapshot implementation, idempotent
 func (p *plugin) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"id":      req.SnapshotId,
@@ -638,7 +638,7 @@ func (p *plugin) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 	return nil, fmt.Errorf("not Implemented")
 }
 
-//ListSnapshots implementation, idempotent
+// ListSnapshots implementation, idempotent
 func (p *plugin) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 	p.logger.WithFields(log.Fields{
 		"sourceVolume": req.SourceVolumeId,
@@ -651,7 +651,7 @@ func (p *plugin) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	return nil, fmt.Errorf("not Implemented")
 }
 
-//ControllerExpandVolume - it will expand volume size in storage pool, idempotent
+// ControllerExpandVolume - it will expand volume size in storage pool, idempotent
 func (p *plugin) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	logCtx := p.logger.WithFields(log.Fields{"volume": req.VolumeId})
 	logCtx.WithFields(log.Fields{

--- a/pkg/local-storage/utils/datacopy/rclone.go
+++ b/pkg/local-storage/utils/datacopy/rclone.go
@@ -2,8 +2,9 @@ package datacopy
 
 import (
 	"fmt"
-	"github.com/hwameistor/hwameistor/pkg/local-storage/exechelper"
 	"time"
+
+	"github.com/hwameistor/hwameistor/pkg/local-storage/exechelper"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -170,10 +171,9 @@ func (rcl *Rclone) SrcMountPointToRemoteMountPoint(jobName, namespace, lvPoolNam
 
 	if err := rcl.dcm.k8sControllerClient.Create(rcl.dcm.ctx, jobStruct); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			fmt.Errorf("Failed to create MigrateJob, Job already exists")
-		} else {
-			return err
+			return fmt.Errorf("failed to create MigrateJob, Job already exists")
 		}
+		return err
 	}
 
 	return nil
@@ -193,12 +193,12 @@ func (rcl *Rclone) WaitMigrateJobTaskDone(jobName, lvName string, waitUntilSucce
 		select {
 		case res := <-resCh:
 			if res.Phase == DataCopyStatusFailed {
-				return fmt.Errorf("Failed to run job %s, message is [TODO] %s", res.JobName, res.Message)
+				return fmt.Errorf("failed to run job %s, message is [TODO] %s", res.JobName, res.Message)
 			} else {
 				return nil
 			}
 		case <-time.After(timeout):
-			return fmt.Errorf("Failed to copy data from srcMountPointName: %s to dstMountPointName: %s, timeout after %s", srcMountPoint+lvName, dstMountPoint+lvName, timeout)
+			return fmt.Errorf("failed to copy data from srcMountPointName: %s to dstMountPointName: %s, timeout after %s", srcMountPoint+lvName, dstMountPoint+lvName, timeout)
 		}
 	}
 

--- a/pkg/local-storage/utils/datacopy/status_generator.go
+++ b/pkg/local-storage/utils/datacopy/status_generator.go
@@ -118,20 +118,20 @@ func (statusGenerator *statusGenerator) onUpdate(_, obj interface{}) {
 	statusGenerator.queue.Add(eventJob)
 }
 
-func (statusGenerator *statusGenerator) onDelete(obj interface{}) {
-	job := obj.(*batchv1.Job)
+// func (statusGenerator *statusGenerator) onDelete(obj interface{}) {
+// 	job := obj.(*batchv1.Job)
 
-	//if !statusGenerator.isReleted(job) {
-	//	return
-	//}
+// 	//if !statusGenerator.isReleted(job) {
+// 	//	return
+// 	//}
 
-	eventJob := &jobWithEvent{
-		Job:   job,
-		Event: "DELETE",
-	}
+// 	eventJob := &jobWithEvent{
+// 		Job:   job,
+// 		Event: "DELETE",
+// 	}
 
-	statusGenerator.queue.Done(eventJob)
-}
+// 	statusGenerator.queue.Done(eventJob)
+// }
 
 func (statusGenerator *statusGenerator) Run() {
 	logger.Debugf("statusGenerator Run")
@@ -273,20 +273,20 @@ func (statusGenerator *statusGenerator) delObject(name, namespace string, obj k8
 	return nil
 }
 
-// TODO This func should as a filter handler in front of the informer
-func (statusGenerator *statusGenerator) isReleted(job *batchv1.Job) bool {
-	if dataCopyStatusJSON, has := job.Annotations[statusGenerator.dataCopyStatusAnnotationName]; has {
-		dataCopyStatus := &DataCopyStatus{}
-		if err := json.Unmarshal([]byte(dataCopyStatusJSON), dataCopyStatus); err != nil {
-			return false
-		}
-		if _, exists := statusGenerator.relatedJobWithResultCh[dataCopyStatus.JobName]; exists {
-			return true
-		}
-	}
+// // TODO This func should as a filter handler in front of the informer
+// func (statusGenerator *statusGenerator) isReleted(job *batchv1.Job) bool {
+// 	if dataCopyStatusJSON, has := job.Annotations[statusGenerator.dataCopyStatusAnnotationName]; has {
+// 		dataCopyStatus := &DataCopyStatus{}
+// 		if err := json.Unmarshal([]byte(dataCopyStatusJSON), dataCopyStatus); err != nil {
+// 			return false
+// 		}
+// 		if _, exists := statusGenerator.relatedJobWithResultCh[dataCopyStatus.JobName]; exists {
+// 			return true
+// 		}
+// 	}
 
-	return false
-}
+// 	return false
+// }
 
 func (statusGenerator *statusGenerator) getJobRunningStatus(job *batchv1.Job) *DataCopyStatus {
 	rcloneRunningStatus := &DataCopyStatus{}


### PR DESCRIPTION
1. converted all the namespaced CRDs to the cluster wide;
2. fixed the volume migrate functions, including HA, convertable and in-convertable volumes
3. added the volume evicted feature