### PR TITLE
fix omitempty struct pointer

### DIFF
--- a/pkg/apis/client/clientset/versioned/fake/register.go
+++ b/pkg/apis/client/clientset/versioned/fake/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/apis/client/clientset/versioned/scheme/register.go
+++ b/pkg/apis/client/clientset/versioned/scheme/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
@@ -145,7 +145,7 @@ type LocalDiskSpec struct {
 
 	// PartitionInfo contains partition information
 	// +optional
-	PartitionInfo []PartitionInfo `json:"partitionInfo,omitempty"`
+	PartitionInfo []*PartitionInfo `json:"partitionInfo,omitempty"`
 
 	// HasRAID identifies if the disk is a raid disk or not
 	HasRAID bool `json:"isRaid,omitempty"`

--- a/pkg/apis/hwameistor/v1alpha1/localdiskvolume_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localdiskvolume_types.go
@@ -86,7 +86,7 @@ type LocalDiskVolumeStatus struct {
 	AllocatedCapacityBytes int64 `json:"allocatedCapacityBytes,omitempty"`
 
 	// MountPoints
-	MountPoints []MountPoint `json:"mountPoints,omitempty"`
+	MountPoints []*MountPoint `json:"mountPoints,omitempty"`
 
 	// State is the phase of volume replica, e.g. Creating, Ready, NotReady, ToBeDeleted, Deleted
 	State State `json:"state,omitempty"`

--- a/pkg/apis/hwameistor/v1alpha1/localvolumegroup_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localvolumegroup_types.go
@@ -14,7 +14,7 @@ type LocalVolumeGroupSpec struct {
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// Volumes is the collection of the volumes in the group
-	Volumes []VolumeInfo `json:"volumes,omitempty"`
+	Volumes []*VolumeInfo `json:"volumes,omitempty"`
 
 	// Accessibility is the topology requirement of the volume. It describes how to locate and distribute the volume replicas
 	Accessibility AccessibilityTopology `json:"accessibility,omitempty"`

--- a/pkg/apis/hwameistor/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hwameistor/v1alpha1/zz_generated.deepcopy.go
@@ -424,8 +424,14 @@ func (in *LocalDiskSpec) DeepCopyInto(out *LocalDiskSpec) {
 	*out = *in
 	if in.PartitionInfo != nil {
 		in, out := &in.PartitionInfo, &out.PartitionInfo
-		*out = make([]PartitionInfo, len(*in))
-		copy(*out, *in)
+		*out = make([]*PartitionInfo, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(PartitionInfo)
+				**out = **in
+			}
+		}
 	}
 	out.RAIDInfo = in.RAIDInfo
 	out.SmartInfo = in.SmartInfo
@@ -547,9 +553,13 @@ func (in *LocalDiskVolumeStatus) DeepCopyInto(out *LocalDiskVolumeStatus) {
 	*out = *in
 	if in.MountPoints != nil {
 		in, out := &in.MountPoints, &out.MountPoints
-		*out = make([]MountPoint, len(*in))
+		*out = make([]*MountPoint, len(*in))
 		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(MountPoint)
+				(*in).DeepCopyInto(*out)
+			}
 		}
 	}
 	return
@@ -1002,8 +1012,14 @@ func (in *LocalVolumeGroupSpec) DeepCopyInto(out *LocalVolumeGroupSpec) {
 	*out = *in
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
-		*out = make([]VolumeInfo, len(*in))
-		copy(*out, *in)
+		*out = make([]*VolumeInfo, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(VolumeInfo)
+				**out = **in
+			}
+		}
 	}
 	in.Accessibility.DeepCopyInto(&out.Accessibility)
 	if in.Pods != nil {

--- a/pkg/local-disk-manager/builder/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/builder/localdisk/localdisk.go
@@ -86,7 +86,7 @@ func (builder *Builder) SetupPartitionInfo(originParts []manager.PartitionInfo) 
 	}
 	for _, part := range originParts {
 		builder.disk.Spec.HasPartition = true
-		p := v1alpha1.PartitionInfo{}
+		p := &v1alpha1.PartitionInfo{}
 		p.HasFileSystem = true
 		p.FileSystem.Type = part.Filesystem
 		builder.disk.Spec.PartitionInfo = append(builder.disk.Spec.PartitionInfo, p)

--- a/pkg/local-disk-manager/filter/filter_disk_test.go
+++ b/pkg/local-disk-manager/filter/filter_disk_test.go
@@ -152,7 +152,7 @@ func TestLocalDiskFilter(t *testing.T) {
 			WantDiskNoPartition: true,
 			disk:                GenFakeLocalDiskObject(),
 			setProperty: func(disk *v1alpha1.LocalDisk) {
-				disk.Spec.PartitionInfo = append(disk.Spec.PartitionInfo, v1alpha1.PartitionInfo{
+				disk.Spec.PartitionInfo = append(disk.Spec.PartitionInfo, &v1alpha1.PartitionInfo{
 					Path:          "",
 					HasFileSystem: false,
 					FileSystem:    v1alpha1.FileSystemInfo{},

--- a/pkg/local-disk-manager/handler/localdiskvolume/localdiskvolume.go
+++ b/pkg/local-disk-manager/handler/localdiskvolume/localdiskvolume.go
@@ -180,7 +180,7 @@ func (v *DiskVolumeHandler) AddFinalizers(finalizer []string) {
 	//return
 }
 
-func (v *DiskVolumeHandler) GetMountPoints() []v1alpha1.MountPoint {
+func (v *DiskVolumeHandler) GetMountPoints() []*v1alpha1.MountPoint {
 	return v.Ldv.Status.MountPoints
 }
 
@@ -268,7 +268,7 @@ func (v *DiskVolumeHandler) ExistMountPoint(targetPath string) bool {
 }
 
 func (v *DiskVolumeHandler) AppendMountPoint(targetPath string, volCap *csi.VolumeCapability) {
-	mountPoint := v1alpha1.MountPoint{TargetPath: targetPath, Phase: v1alpha1.MountPointToBeMounted}
+	mountPoint := &v1alpha1.MountPoint{TargetPath: targetPath, Phase: v1alpha1.MountPointToBeMounted}
 	switch volCap.AccessType.(type) {
 	case *csi.VolumeCapability_Block:
 		mountPoint.VolumeCap = v1alpha1.VolumeCapability{AccessType: v1alpha1.VolumeCapability_AccessType_Block}

--- a/pkg/local-storage/controller/localvolumegroup/localvolumegroup_controller_test.go
+++ b/pkg/local-storage/controller/localvolumegroup/localvolumegroup_controller_test.go
@@ -48,7 +48,7 @@ var (
 	fakePods                             = []string{"pod-test1"}
 	fakeAcesscibility                    = apisv1alpha1.AccessibilityTopology{Nodes: []string{"test-node1"}}
 	fakeLocalVolumeName                  = "local-volume-test1"
-	fakeVolumes                          = []apisv1alpha1.VolumeInfo{{LocalVolumeName: fakeLocalVolumeName, PersistentVolumeClaimName: fakePersistentPvcName}}
+	fakeVolumes                          = []*apisv1alpha1.VolumeInfo{{LocalVolumeName: fakeLocalVolumeName, PersistentVolumeClaimName: fakePersistentPvcName}}
 	apiversion                           = "hwameistor.io/v1alpha1"
 	LocalVolumeGroupKind                 = "LocalVolumeGroup"
 	fakeRecorder                         = record.NewFakeRecorder(100)

--- a/pkg/local-storage/controller/localvolumemigrate/localvolumemigrate_controller_test.go
+++ b/pkg/local-storage/controller/localvolumemigrate/localvolumemigrate_controller_test.go
@@ -35,7 +35,7 @@ var (
 	// fakeSourceNodenames                   = []string{"10-6-118-10"}
 	// fakeTargetNodenames                   = []string{"10-6-118-11"}
 	fakePersistentPvcName = "pvc-test"
-	fakeVolumes           = []apisv1alpha1.VolumeInfo{{LocalVolumeName: fakeLocalVolumeName, PersistentVolumeClaimName: fakePersistentPvcName}}
+	fakeVolumes           = []*apisv1alpha1.VolumeInfo{{LocalVolumeName: fakeLocalVolumeName, PersistentVolumeClaimName: fakePersistentPvcName}}
 	fakeStorageIp         = "10.6.118.11"
 	fakeZone              = "zone-test"
 	fakeRegion            = "region-test"

--- a/pkg/local-storage/member/controller/volumegroup/manager.go
+++ b/pkg/local-storage/member/controller/volumegroup/manager.go
@@ -558,7 +558,7 @@ func (m *manager) deleteLocalVolume(lvName string) error {
 	}
 
 	modified := false
-	associatedVolumes := []apisv1alpha1.VolumeInfo{}
+	associatedVolumes := []*apisv1alpha1.VolumeInfo{}
 	for i := range lvg.Spec.Volumes {
 		if lvg.Spec.Volumes[i].LocalVolumeName != lvName {
 			associatedVolumes = append(associatedVolumes, lvg.Spec.Volumes[i])
@@ -566,7 +566,7 @@ func (m *manager) deleteLocalVolume(lvName string) error {
 		}
 		if len(lvg.Spec.Volumes[i].PersistentVolumeClaimName) > 0 {
 			associatedVolumes = append(associatedVolumes,
-				apisv1alpha1.VolumeInfo{
+				&apisv1alpha1.VolumeInfo{
 					PersistentVolumeClaimName: lvg.Spec.Volumes[i].PersistentVolumeClaimName,
 				})
 		}
@@ -628,14 +628,14 @@ func (m *manager) deletePVC(namespace string, name string) error {
 	}
 
 	modified := false
-	associatedVolumes := []apisv1alpha1.VolumeInfo{}
+	associatedVolumes := []*apisv1alpha1.VolumeInfo{}
 	for i := range lvg.Spec.Volumes {
 		if lvg.Spec.Volumes[i].PersistentVolumeClaimName != name || lvg.Spec.Namespace != namespace {
 			associatedVolumes = append(associatedVolumes, lvg.Spec.Volumes[i])
 			continue
 		}
 		if len(lvg.Spec.Volumes[i].LocalVolumeName) > 0 {
-			associatedVolumes = append(associatedVolumes, apisv1alpha1.VolumeInfo{LocalVolumeName: lvg.Spec.Volumes[i].LocalVolumeName})
+			associatedVolumes = append(associatedVolumes, &apisv1alpha1.VolumeInfo{LocalVolumeName: lvg.Spec.Volumes[i].LocalVolumeName})
 		}
 		modified = true
 	}

--- a/pkg/local-storage/member/csi/controller.go
+++ b/pkg/local-storage/member/csi/controller.go
@@ -159,14 +159,14 @@ func (p *plugin) getLocalVolumeGroupOrCreate(req *csi.CreateVolumeRequest, param
 		},
 		Spec: apisv1alpha1.LocalVolumeGroupSpec{
 			Namespace: params.pvcNamespace,
-			Volumes:   []apisv1alpha1.VolumeInfo{},
+			Volumes:   []*apisv1alpha1.VolumeInfo{},
 			Accessibility: apisv1alpha1.AccessibilityTopology{
 				Nodes: selectedNodes,
 			},
 		},
 	}
 	for _, lv := range lvs {
-		lvg.Spec.Volumes = append(lvg.Spec.Volumes, apisv1alpha1.VolumeInfo{PersistentVolumeClaimName: lv.Spec.PersistentVolumeClaimName})
+		lvg.Spec.Volumes = append(lvg.Spec.Volumes, &apisv1alpha1.VolumeInfo{PersistentVolumeClaimName: lv.Spec.PersistentVolumeClaimName})
 	}
 	log.WithFields(log.Fields{"lvg": lvg.Name}).Debug("Creating a new LVG ...")
 	if err := p.apiClient.Create(context.Background(), lvg, &client.CreateOptions{}); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
it will panic when PartitionInfo、MountPoints、Volumes len equal zero and k8s version less than 1.20.11, because the HostsMap's type is struct.
if type is struct but not Pointer, omitempty invalidate
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
