### PR TITLE
add fstype into localvolume's status to support datacopy

### DIFF
--- a/deploy/crds/hwameistor.io_localvolumes_crd.yaml
+++ b/deploy/crds/hwameistor.io_localvolumes_crd.yaml
@@ -26,10 +26,6 @@ spec:
       jsonPath: .spec.requiredCapacityBytes
       name: capacity
       type: integer
-    - description: Accessibility of volume
-      jsonPath: .spec.accessibility.node
-      name: accessibility
-      type: string
     - description: State of the volume
       jsonPath: .status.state
       name: state
@@ -41,6 +37,10 @@ spec:
     - description: Name of the node where the volume is in-use
       jsonPath: .status.publishedNode
       name: published
+      type: string
+    - description: Filesystem type of this volume
+      jsonPath: .status.fsType
+      name: fstype
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: age
@@ -193,6 +193,9 @@ spec:
                   replicas, the value is equal to the one of a replica's size
                 format: int64
                 type: integer
+              fsType:
+                description: PublishFSType is the fstype on this volume
+                type: string
               publishedNode:
                 description: PublishedNodeName is the node where the volume is published
                   and used by pod

--- a/deploy/crds/hwameistor.io_localvolumes_crd.yaml
+++ b/deploy/crds/hwameistor.io_localvolumes_crd.yaml
@@ -139,9 +139,11 @@ spec:
                   volumeName:
                     type: string
                 required:
+                - convertible
                 - initialized
                 - readyToInitialize
                 - replicas
+                - requiredCapacityBytes
                 - resourceID
                 - version
                 - volumeName
@@ -194,12 +196,16 @@ spec:
                 format: int64
                 type: integer
               fsType:
-                description: PublishFSType is the fstype on this volume
+                description: PublishedFSType is the fstype on this volume
                 type: string
               publishedNode:
                 description: PublishedNodeName is the node where the volume is published
                   and used by pod
                 type: string
+              rawblock:
+                default: false
+                description: PublishedRawBlock is for raw block
+                type: boolean
               replicas:
                 description: Volume is a logical concept and composed by one or many
                   replicas which will be located at different node.
@@ -210,6 +216,8 @@ spec:
                 description: State is the phase of volume replica, e.g. Creating,
                   Ready, NotReady, ToBeDeleted, Deleted
                 type: string
+            required:
+            - rawblock
             type: object
         type: object
     served: true

--- a/helm/hwameistor/crds/hwameistor.io_localvolumes_crd.yaml
+++ b/helm/hwameistor/crds/hwameistor.io_localvolumes_crd.yaml
@@ -26,10 +26,6 @@ spec:
       jsonPath: .spec.requiredCapacityBytes
       name: capacity
       type: integer
-    - description: Accessibility of volume
-      jsonPath: .spec.accessibility.node
-      name: accessibility
-      type: string
     - description: State of the volume
       jsonPath: .status.state
       name: state
@@ -41,6 +37,10 @@ spec:
     - description: Name of the node where the volume is in-use
       jsonPath: .status.publishedNode
       name: published
+      type: string
+    - description: Filesystem type of this volume
+      jsonPath: .status.fsType
+      name: fstype
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: age
@@ -193,6 +193,9 @@ spec:
                   replicas, the value is equal to the one of a replica's size
                 format: int64
                 type: integer
+              fsType:
+                description: PublishFSType is the fstype on this volume
+                type: string
               publishedNode:
                 description: PublishedNodeName is the node where the volume is published
                   and used by pod

--- a/helm/hwameistor/crds/hwameistor.io_localvolumes_crd.yaml
+++ b/helm/hwameistor/crds/hwameistor.io_localvolumes_crd.yaml
@@ -139,9 +139,11 @@ spec:
                   volumeName:
                     type: string
                 required:
+                - convertible
                 - initialized
                 - readyToInitialize
                 - replicas
+                - requiredCapacityBytes
                 - resourceID
                 - version
                 - volumeName
@@ -194,12 +196,16 @@ spec:
                 format: int64
                 type: integer
               fsType:
-                description: PublishFSType is the fstype on this volume
+                description: PublishedFSType is the fstype on this volume
                 type: string
               publishedNode:
                 description: PublishedNodeName is the node where the volume is published
                   and used by pod
                 type: string
+              rawblock:
+                default: false
+                description: PublishedRawBlock is for raw block
+                type: boolean
               replicas:
                 description: Volume is a logical concept and composed by one or many
                   replicas which will be located at different node.
@@ -210,6 +216,8 @@ spec:
                 description: State is the phase of volume replica, e.g. Creating,
                   Ready, NotReady, ToBeDeleted, Deleted
                 type: string
+            required:
+            - rawblock
             type: object
         type: object
     served: true

--- a/pkg/apis/hwameistor/v1alpha1/localvolume_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localvolume_types.go
@@ -164,6 +164,8 @@ type LocalVolumeStatus struct {
 	// PublishedNodeName is the node where the volume is published and used by pod
 	PublishedNodeName string `json:"publishedNode,omitempty"`
 
+	// PublishFSType is the fstype on this volume
+	PublishFSType string `json:"fsType,omitempty"`
 	// Synced is the sync state of the volume replica, which is important in HA volume
 	// +kubebuilder:default:=false
 	//Synced bool `json:"synced,omitempty"`
@@ -179,10 +181,10 @@ type LocalVolumeStatus struct {
 // +kubebuilder:printcolumn:name="pool",type=string,JSONPath=`.spec.poolName`,description="Name of storage pool"
 // +kubebuilder:printcolumn:name="replicas",type=integer,JSONPath=`.spec.replicaNumber`,description="Number of volume replica"
 // +kubebuilder:printcolumn:name="capacity",type=integer,JSONPath=`.spec.requiredCapacityBytes`,description="Required capacity of the volume"
-// +kubebuilder:printcolumn:name="accessibility",type=string,JSONPath=`.spec.accessibility.node`,description="Accessibility of volume"
 // +kubebuilder:printcolumn:name="state",type=string,JSONPath=`.status.state`,description="State of the volume"
 // +kubebuilder:printcolumn:name="resource",type=integer,JSONPath=`.spec.config.resourceID`,description="Allocated resource ID for the volume"
 // +kubebuilder:printcolumn:name="published",type=string,JSONPath=`.status.publishedNode`,description="Name of the node where the volume is in-use"
+// +kubebuilder:printcolumn:name="fstype",type=string,JSONPath=`.status.fsType`,description="Filesystem type of this volume"
 // +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`
 type LocalVolume struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/hwameistor/v1alpha1/localvolume_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localvolume_types.go
@@ -69,10 +69,10 @@ type VolumeConfig struct {
 	// Version of config, start from 0, plus 1 every time config update
 	Version               int    `json:"version"`
 	VolumeName            string `json:"volumeName"`
-	RequiredCapacityBytes int64  `json:"requiredCapacityBytes,omitempty"`
+	RequiredCapacityBytes int64  `json:"requiredCapacityBytes"`
 
 	// Convertible is to indicate if the non-HA volume can be transitted to HA volume or not
-	Convertible bool `json:"convertible,omitempty"`
+	Convertible bool `json:"convertible"`
 
 	// ResourceID is for HA volume, set to '-1' for non-HA volume
 	ResourceID        int             `json:"resourceID"`
@@ -164,8 +164,12 @@ type LocalVolumeStatus struct {
 	// PublishedNodeName is the node where the volume is published and used by pod
 	PublishedNodeName string `json:"publishedNode,omitempty"`
 
-	// PublishFSType is the fstype on this volume
-	PublishFSType string `json:"fsType,omitempty"`
+	// PublishedFSType is the fstype on this volume
+	PublishedFSType string `json:"fsType,omitempty"`
+
+	// PublishedRawBlock is for raw block
+	// +kubebuilder:default:=false
+	PublishedRawBlock bool `json:"rawblock"`
 	// Synced is the sync state of the volume replica, which is important in HA volume
 	// +kubebuilder:default:=false
 	//Synced bool `json:"synced,omitempty"`

--- a/pkg/local-storage/member/controller/volume_migrate_task_worker.go
+++ b/pkg/local-storage/member/controller/volume_migrate_task_worker.go
@@ -139,6 +139,14 @@ func (m *manager) volumeMigrateSubmit(migrate *apisv1alpha1.LocalVolumeMigrate, 
 		return fmt.Errorf("volume still in use")
 	}
 
+	// consider the localvolume version after the upgrade, comment out the fstype check.
+	// if !vol.Spec.Convertible && len(vol.Status.PublishFSType) == 0 {
+	// 	logCtx.WithField("fstype", vol.Status.PublishFSType).Warning("Can't identify the filesystem type on the LocalVolume")
+	// 	migrate.Status.Message = "can't identify the filesystem"
+	// 	m.apiClient.Status().Update(ctx, migrate)
+	// 	return fmt.Errorf("can't identify the filesystem")
+	// }
+
 	if len(migrate.Status.TargetNode) == 0 {
 		logCtx.Debug("Selecting the target node for the migration")
 		tgtNodeName, err := m.selectMigrateTargetNode(migrate, lvg)

--- a/pkg/local-storage/member/controller/volume_migrate_task_worker.go
+++ b/pkg/local-storage/member/controller/volume_migrate_task_worker.go
@@ -139,13 +139,12 @@ func (m *manager) volumeMigrateSubmit(migrate *apisv1alpha1.LocalVolumeMigrate, 
 		return fmt.Errorf("volume still in use")
 	}
 
-	// consider the localvolume version after the upgrade, comment out the fstype check.
-	// if !vol.Spec.Convertible && len(vol.Status.PublishFSType) == 0 {
-	// 	logCtx.WithField("fstype", vol.Status.PublishFSType).Warning("Can't identify the filesystem type on the LocalVolume")
-	// 	migrate.Status.Message = "can't identify the filesystem"
-	// 	m.apiClient.Status().Update(ctx, migrate)
-	// 	return fmt.Errorf("can't identify the filesystem")
-	// }
+	if !vol.Spec.Convertible && vol.Status.PublishedRawBlock {
+		logCtx.Warning("Can't migrate the unconvertable raw block volume")
+		migrate.Status.Message = "Can't migrate the unconvertable raw block volume"
+		m.apiClient.Status().Update(ctx, migrate)
+		return fmt.Errorf("can't migrate the unconvertable raw block volume")
+	}
 
 	if len(migrate.Status.TargetNode) == 0 {
 		logCtx.Debug("Selecting the target node for the migration")

--- a/pkg/local-storage/member/csi/controller.go
+++ b/pkg/local-storage/member/csi/controller.go
@@ -445,6 +445,9 @@ func (p *plugin) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 			return resp, fmt.Errorf("invalid device path of volume replica")
 
 		}
+		if req.VolumeCapability.GetBlock() == nil && req.VolumeCapability.GetMount() != nil {
+			vol.Status.PublishFSType = req.VolumeCapability.GetMount().FsType
+		}
 		vol.Status.PublishedNodeName = req.NodeId
 		if err := p.apiClient.Status().Update(ctx, vol); err != nil {
 			p.logger.WithFields(log.Fields{"volume": vol.Name, "node": req.NodeId}).Error("Failed to update volume with published node info")

--- a/pkg/local-storage/member/csi/controller.go
+++ b/pkg/local-storage/member/csi/controller.go
@@ -445,8 +445,14 @@ func (p *plugin) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 			return resp, fmt.Errorf("invalid device path of volume replica")
 
 		}
-		if req.VolumeCapability.GetBlock() == nil && req.VolumeCapability.GetMount() != nil {
-			vol.Status.PublishFSType = req.VolumeCapability.GetMount().FsType
+		if req.VolumeCapability.GetBlock() != nil {
+			vol.Status.PublishedRawBlock = true
+		} else if req.VolumeCapability.GetMount() != nil {
+			if len(req.VolumeCapability.GetMount().FsType) == 0 {
+				vol.Status.PublishedFSType = "ext4"
+			} else {
+				vol.Status.PublishedFSType = req.VolumeCapability.GetMount().FsType
+			}
 		}
 		vol.Status.PublishedNodeName = req.NodeId
 		if err := p.apiClient.Status().Update(ctx, vol); err != nil {

--- a/pkg/local-storage/member/csi/parser.go
+++ b/pkg/local-storage/member/csi/parser.go
@@ -20,6 +20,7 @@ type volumeParameters struct {
 	poolName      string
 	replicaNumber int64
 	convertible   bool
+	fsType        string
 	pvcName       string
 	pvcNamespace  string
 }
@@ -61,6 +62,11 @@ func parseParameters(req RequestParameterHandler) (*volumeParameters, error) {
 		}
 	}
 
+	fsType, ok := params[apisv1alpha1.VolumeParameterFSTypeKey]
+	if !ok {
+		return nil, fmt.Errorf("not found fstype")
+	}
+
 	pvcNamespace, ok := params[pvcNamespaceKey]
 	if !ok {
 		return nil, fmt.Errorf("not found pvc namespace")
@@ -76,6 +82,7 @@ func parseParameters(req RequestParameterHandler) (*volumeParameters, error) {
 		poolName:      poolName,
 		replicaNumber: int64(replicaNumber),
 		convertible:   convertible,
+		fsType:        fsType,
 		pvcNamespace:  pvcNamespace,
 		pvcName:       pvcName,
 	}, nil

--- a/pkg/local-storage/member/node/rclone_volume_mount_worker.go
+++ b/pkg/local-storage/member/node/rclone_volume_mount_worker.go
@@ -96,9 +96,14 @@ func (m *manager) processRcloneVolumeMount(lvName string) error {
 	newLvName := strings.Replace(lvName, "-", "--", -1)
 	devPath := fmt.Sprintf("/dev/mapper/%s-%s", vol.Spec.PoolName, newLvName)
 
+	fsType := vol.Status.PublishedFSType
+	if len(fsType) == 0 {
+		// in case of the upgrade
+		fsType = "xfs"
+	}
 	// return directly if device has already mounted at TargetPath
 	if !isStringInArray(mountPoint, m.mounter.GetDeviceMountPoints(devPath)) {
-		if err := m.mounter.FormatAndMount(devPath, mountPoint, vol.Status.PublishFSType, []string{}); err != nil {
+		if err := m.mounter.FormatAndMount(devPath, mountPoint, fsType, []string{}); err != nil {
 			m.logger.WithField("mountpoint", mountPoint).WithError(err).Error("Failed to FormatAndMount volume")
 			return err
 		}

--- a/pkg/local-storage/member/node/rclone_volume_mount_worker.go
+++ b/pkg/local-storage/member/node/rclone_volume_mount_worker.go
@@ -96,11 +96,9 @@ func (m *manager) processRcloneVolumeMount(lvName string) error {
 	newLvName := strings.Replace(lvName, "-", "--", -1)
 	devPath := fmt.Sprintf("/dev/mapper/%s-%s", vol.Spec.PoolName, newLvName)
 
-	// ??? filesystem type should be checked from the replicas
-	fsType := "xfs"
 	// return directly if device has already mounted at TargetPath
 	if !isStringInArray(mountPoint, m.mounter.GetDeviceMountPoints(devPath)) {
-		if err := m.mounter.FormatAndMount(devPath, mountPoint, fsType, []string{}); err != nil {
+		if err := m.mounter.FormatAndMount(devPath, mountPoint, vol.Status.PublishFSType, []string{}); err != nil {
 			m.logger.WithField("mountpoint", mountPoint).WithError(err).Error("Failed to FormatAndMount volume")
 			return err
 		}


### PR DESCRIPTION
Currently, the migrate by rclone can support xfs filesystem only. Add fstype info into localvolume to support multiple types
