### PR TITLE
updated CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,103 @@
+# HwameiStor Code of Conduct
+
+A primary goal of HwameiStor is to be inclusive to the largest number of contributors,
+with the most varied and diverse backgrounds possible. As such, we are committed to
+providing a friendly, safe, and welcoming environment for all, regardless of gender,
+sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+
+This code of conduct outlines our expectations for all those who participate in our community,
+as well as the consequences for any unacceptable behavior.
+
+We invite all those who participate in HwameiStor to help us create safe and positive experiences for everyone.
+
+## Open [Source/Culture/Tech] Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship
+by encouraging participants to recognize and strengthen the relationships between our actions and
+their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract
+the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly,
+and encourages all participants to contribute to the fullest extent, we want to know.
+
+## Expected Behaviors
+
+The following behaviors are expected and requested of all community members:
+
+- Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+- Exercise consideration and respect in your speech and actions.
+- Attempt collaboration before conflict.
+- Refrain from demeaning, discriminatory, or harassing behavior and speech.
+- Be mindful of your surroundings and of your fellow participants. Alert community leaders
+  if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct,
+  even if they seem inconsequential.
+- Remember that community event venues may be shared with members of the public; please be
+  respectful to all patrons of these locations.
+
+## Unacceptable Behaviors
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+- Violence, threats of violence or violent language directed against another person.
+- Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+- Posting or displaying sexually explicit or violent material.
+- Posting or threatening to post other people's personally identifying information ("doxing").
+- Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+- Inappropriate photography or recording.
+- Inappropriate physical contact. You should have someone's consent before touching them.
+- Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+- Deliberate intimidation, stalking or following (online or in person).
+- Advocating for, or encouraging, any of the above behavior.
+- Sustained disruption of community events, including talks and presentations.
+
+## Consequences of Unacceptable Behaviors
+
+Unacceptable behavior from any community member, including sponsors and those with
+decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers
+may take any action they deem appropriate, up to and including a temporary ban or
+permanent expulsion from the community without warning (and without refund in the
+case of a paid event).
+
+## Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, or have any other concerns,
+please notify the community as soon as possible and [open an issue](https://github.com/hwameistor/hwameistor/issues).
+
+Additionally, community organizers are available to help community members engage
+with local law enforcement or to otherwise help those experiencing unacceptable
+behavior feel safe. In the context of in-person events, organizers will also provide
+escorts as desired by the person experiencing distress.
+
+## Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct,
+you should notify HwameiStor with a concise description of your grievance. Your grievance
+will be handled in accordance with our existing governing policies.
+
+## Scope
+
+We expect all community participants (contributors, sponsors, and other
+guests) to abide by this Code of Conduct in all community venues - online and in-person - as
+well as in all one-on-one communications pertaining to community business.
+
+This code of conduct and its related procedures also applies to unacceptable behavior
+occurring outside the scope of community activities when such behavior has the potential
+to adversely affect the safety and well-being of community members.
+
+## Other
+
+As a project listed in CNCF landscape, we also respect and follow
+[CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+If you have any question please reach out us, you can
+
+- chat with [slack](https://join.slack.com/t/hwameistor/shared_invite/zt-1dkabcq2c-KIRBJDBc_GgZZfeLrooK6g)
+- join the wechat group to chat more
+
+  ![QR code for Wechat](./docs/docs/img/wechat.png)


### PR DESCRIPTION
Added text in `CODE_OF_CONDUCT.md` by following [DaoCloud Code of Conduce](https://github.com/DaoCloud/DaoCloud-docs/blob/main/CODE_OF_CONDUCT.md) and [CNCF code of conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

```release-note
NONE
```
