### PR TITLE
Remove kubeconfig in scheduler config

### DIFF
--- a/helm/hwameistor/templates/scheduler-config.yaml
+++ b/helm/hwameistor/templates/scheduler-config.yaml
@@ -25,3 +25,4 @@ data:
     leaderElection:
       leaderElect: true
       resourceName: hwameistor-scheduler
+      

--- a/helm/hwameistor/templates/scheduler-config.yaml
+++ b/helm/hwameistor/templates/scheduler-config.yaml
@@ -25,5 +25,3 @@ data:
     leaderElection:
       leaderElect: true
       resourceName: hwameistor-scheduler
-    clientConnection:
-      kubeconfig: /etc/kubernetes/scheduler.conf

--- a/helm/hwameistor/templates/scheduler.yaml
+++ b/helm/hwameistor/templates/scheduler.yaml
@@ -29,7 +29,6 @@ spec:
       - args:
         - -v=2
         - --bind-address=0.0.0.0
-        - --kubeconfig=/etc/kubernetes/scheduler.conf
         - --leader-elect=false
         - --leader-elect-resource-name=hwameistor-scheduler
         - --leader-elect-resource-namespace={{ .Release.Namespace}}
@@ -42,17 +41,10 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/scheduler.conf
-          name: kubeconfig
-          readOnly: true
         - mountPath: /etc/hwameistor/
           name: hwameistor-scheduler-config
           readOnly: true
       volumes:
-      - hostPath:
-          path: {{ .Values.scheduler.kubeApiServerConfigFilePath}}
-          type: FileOrCreate
-        name: kubeconfig
       - configMap:
           name: hwameistor-scheduler-config 
           items:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
fix error when apiserver address in scheduler-config on host is `127.0.0.1`

Relevant issue: https://github.com/hwameistor/hwameistor/issues/521

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
