### PR TITLE
only watch target namespace job when datacopy

### DIFF
--- a/pkg/local-storage/member/controller/manager.go
+++ b/pkg/local-storage/member/controller/manager.go
@@ -70,7 +70,7 @@ type manager struct {
 // New cluster manager
 func New(name string, namespace string, cli client.Client, scheme *runtime.Scheme, informersCache runtimecache.Cache, systemConfig apisv1alpha1.SystemConfig) (apis.ControllerManager, error) {
 	dataCopyStatusCh := make(chan *datacopyutil.DataCopyStatus, 100)
-	dcm, _ := datacopyutil.NewDataCopyManager(context.TODO(), "", cli, dataCopyStatusCh)
+	dcm, _ := datacopyutil.NewDataCopyManager(context.TODO(), "", cli, dataCopyStatusCh, namespace)
 	return &manager{
 		name:                        name,
 		namespace:                   namespace,

--- a/pkg/local-storage/utils/datacopy/manager.go
+++ b/pkg/local-storage/utils/datacopy/manager.go
@@ -31,17 +31,15 @@ type DataCopyManager struct {
 //
 // It will feedback copy process status continuously through statusCh,
 // so it dose not need ResourceReady to poll resource status
-func NewDataCopyManager(ctx context.Context,
-	dataCopyJobStatusAnnotationName string,
-	client k8sclient.Client,
-	statusCh chan *DataCopyStatus) (*DataCopyManager, error) {
+func NewDataCopyManager(ctx context.Context, dataCopyJobStatusAnnotationName string,
+	client k8sclient.Client, statusCh chan *DataCopyStatus, namespace string) (*DataCopyManager, error) {
 	dcm := &DataCopyManager{
 		dataCopyJobStatusAnnotationName: dataCopyJobStatusAnnotationName,
 		k8sControllerClient:             client,
 		ctx:                             ctx,
 	}
 
-	statusGenerator, err := newStatusGenerator(dcm, dataCopyJobStatusAnnotationName, statusCh)
+	statusGenerator, err := newStatusGenerator(dcm, dataCopyJobStatusAnnotationName, statusCh, namespace)
 	if err != nil {
 		logger.WithError(err).Error("Failed to init StatusGenerator")
 		return nil, err

--- a/pkg/local-storage/utils/datacopy/status_generator.go
+++ b/pkg/local-storage/utils/datacopy/status_generator.go
@@ -47,9 +47,8 @@ type statusGenerator struct {
 	relatedJobWithResultCh map[string]chan *DataCopyStatus
 }
 
-func newStatusGenerator(dcm *DataCopyManager,
-	dataCopyStatusAnnotationName string,
-	statusCh chan *DataCopyStatus) (*statusGenerator, error) {
+func newStatusGenerator(dcm *DataCopyManager, dataCopyStatusAnnotationName string,
+	statusCh chan *DataCopyStatus, namespace string) (*statusGenerator, error) {
 	statusGenerator := &statusGenerator{
 		dcm:                          dcm,
 		dataCopyStatusAnnotationName: dataCopyStatusAnnotationName,
@@ -67,7 +66,8 @@ func newStatusGenerator(dcm *DataCopyManager,
 	if err != nil {
 		return nil, err
 	}
-	factory := k8sinformers.NewSharedInformerFactory(k8sClientset, 0)
+	factory := k8sinformers.NewSharedInformerFactoryWithOptions(k8sClientset, 0,
+		k8sinformers.WithNamespace(namespace))
 	informer := factory.Batch().V1().Jobs().Informer()
 	informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 		AddFunc:    statusGenerator.onAdd,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
- Reduce unnecessary JOB events
- Prevent to effect the JOBs in user namespace
#### Special notes for your reviewer:
Our `DateCopy Job` is only running in the namespace where `hwameistor` componnents are running. So we don't need to worry about JOB events missing after applying `namespace` filter option.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
