### PR TITLE
use lease election before becoming leader

### DIFF
--- a/pkg/local-storage/utils/utils.go
+++ b/pkg/local-storage/utils/utils.go
@@ -205,6 +205,16 @@ func GetNodeName() string {
 	return nodeName
 }
 
+func GetPodName() string {
+	podName, ok := os.LookupEnv("POD_NAME")
+	if !ok {
+		log.Errorf("Failed to get POD_NAME from ENV")
+		return ""
+	}
+
+	return podName
+}
+
 // GetNamespace get Namespace from env, else it returns error
 func GetNamespace() string {
 	ns, ok := os.LookupEnv("POD_NAMESPACE")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Reduce worker `log output `when use ConfigMap to lock which provided by Operator-sdk.

Worker Log Output(Before):
```console
$ kubectl logs po/hwameistor-local-disk-manager-tc55n manager
{"level":"info","ts":1673577253.4599922,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1673577272.2874846,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1673577289.80751,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1673577306.4747293,"logger":"leader","msg":"Not the leader. Waiting."}

```
#### Special notes for your reviewer:
N/A
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```
