### PR TITLE
fix potenitial panic in raid

### DIFF
--- a/pkg/local-disk-manager/raid/stor/stor.go
+++ b/pkg/local-disk-manager/raid/stor/stor.go
@@ -8,19 +8,24 @@ import (
 )
 
 const (
+	// The storcli is the command line management software designed for the MegaRAID® product line.
 	defaultCmd = "storcli"
 
+	// Print the number of controllers connected in JSON format.
 	STOR_SHOW_CTRL_COUNT = "show ctrlcount j"
 )
 
+// Stor implements the raid.Manager interface.
 type Stor struct {
 	Path string `json:"Path"`
 }
 
+// NewStor returns a Stor instance with default values.
 func NewStor() *Stor {
 	return &Stor{Path: defaultCmd}
 }
 
+// GetControllerCount implements the raid.Manager interface.
 func (s *Stor) GetControllerCount() (int, error) {
 	var (
 		count  int
@@ -37,6 +42,10 @@ func (s *Stor) GetControllerCount() (int, error) {
 	err = json.Unmarshal(info, &result)
 	if err != nil {
 		return count, err
+	}
+
+	if len(result.Controllers) < 1 {
+		return count, fmt.Errorf("no controller found in the result: %v", result)
 	}
 
 	if result.Controllers[0].CommandStatus.Status == "Success" {


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
