### PR TITLE
[Enhance] Resize StoragePool Capacity when disk capacity changed

### DIFF
--- a/pkg/local-storage/member/node/local_disk_task_worker.go
+++ b/pkg/local-storage/member/node/local_disk_task_worker.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"github.com/hwameistor/hwameistor/pkg/local-storage/member/node/diskmonitor"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -10,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	apisv1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
+	"github.com/hwameistor/hwameistor/pkg/local-storage/member/node/diskmonitor"
 )
 
 func (m *manager) startLocalDiskTaskWorker(stopCh <-chan struct{}) {
@@ -104,12 +104,12 @@ func (m *manager) resizeStoragePoolCapacity(localDisk *apisv1alpha1.LocalDisk) e
 	// find out if disk has used in StoragePool and compare recorded capacity and current capacity
 	// if capacity has been resized, rebuild localstorage registry and update node resource
 	registeredDisks := m.Storage().Registry().Disks()
-	registererDisk, exist := registeredDisks[localDisk.Spec.DevicePath]
+	registeredDisk, exist := registeredDisks[localDisk.Spec.DevicePath]
 	if !exist {
 		return nil
 	}
 
-	if !m.needResizePVCapacity(localDisk.Spec.Capacity, registererDisk.CapacityBytes) {
+	if !m.needResizePVCapacity(localDisk.Spec.Capacity, registeredDisk.CapacityBytes) {
 		return nil
 	}
 

--- a/pkg/local-storage/member/node/local_disk_task_worker.go
+++ b/pkg/local-storage/member/node/local_disk_task_worker.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"math"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -148,5 +149,5 @@ func (m *manager) handleDiskStateChange(localDisk *apisv1alpha1.LocalDisk) {
 func (m *manager) needResizePVCapacity(currentCapacity, recordCapacity int64) bool {
 	// consider metadata size, the capacity in pv may smaller than actual disk capacity
 	var pe = 4 * 1024 * 1024
-	return (currentCapacity - recordCapacity) > int64(pe)
+	return math.Abs(float64(currentCapacity-recordCapacity)) > float64(pe)
 }

--- a/pkg/local-storage/member/node/manager.go
+++ b/pkg/local-storage/member/node/manager.go
@@ -226,6 +226,7 @@ func (m *manager) setupInformers() {
 		m.logger.WithError(err).Fatal("Failed to get informer for localDisk")
 	}
 	localDiskInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    m.handleLocalDiskAdd,
 		UpdateFunc: m.handleLocalDiskUpdate,
 	})
 
@@ -408,6 +409,14 @@ func (m *manager) handleLocalDiskClaimAdd(obj interface{}) {
 }
 
 func (m *manager) handleLocalDiskUpdate(oldObj, newObj interface{}) {
+	localDisk, _ := newObj.(*apisv1alpha1.LocalDisk)
+	if localDisk.Spec.NodeName != m.name {
+		return
+	}
+	m.localDiskTaskQueue.Add(localDisk.Namespace + "/" + localDisk.Name)
+}
+
+func (m *manager) handleLocalDiskAdd(newObj interface{}) {
 	localDisk, _ := newObj.(*apisv1alpha1.LocalDisk)
 	if localDisk.Spec.NodeName != m.name {
 		return

--- a/pkg/local-storage/member/node/storage/executor_lvm.go
+++ b/pkg/local-storage/member/node/storage/executor_lvm.go
@@ -91,6 +91,24 @@ type lvStatus struct {
 	state apisv1alpha1.State
 }
 
+type localDevicesArray []*apisv1alpha1.LocalDevice
+
+func (l localDevicesArray) string() (ds string) {
+	for _, device := range l {
+		ds = ds + device.DevPath + ","
+	}
+	return strings.TrimSuffix(ds, ",")
+}
+
+type localDevicesMap map[string]*apisv1alpha1.LocalDevice
+
+func (l localDevicesMap) string() (ds string) {
+	for _, device := range l {
+		ds = ds + device.DevPath + ","
+	}
+	return strings.TrimSuffix(ds, ",")
+}
+
 type lvmExecutor struct {
 	lm      *LocalManager
 	cmdExec exechelper.Executor
@@ -332,14 +350,7 @@ func (lvm *lvmExecutor) TestVolumeReplica(replica *apisv1alpha1.LocalVolumeRepli
 }
 
 func (lvm *lvmExecutor) ExtendPools(localDevices []*apisv1alpha1.LocalDevice) (bool, error) {
-	stringDevices := func(devs []*apisv1alpha1.LocalDevice) (ds string) {
-		for _, device := range devs {
-			ds = ds + device.DevPath + ","
-		}
-		return strings.TrimSuffix(ds, ",")
-	}
-
-	lvm.logger.Debugf("Start extending pool disk(s): %s, count: %d\n", stringDevices(localDevices), len(localDevices))
+	lvm.logger.Debugf("Start extending pool disk(s): %s, count: %d", localDevicesArray(localDevices).string(), len(localDevices))
 
 	extend := false
 	existingPVMap, err := lvm.getExistingPVs()
@@ -370,7 +381,7 @@ func (lvm *lvmExecutor) ExtendPools(localDevices []*apisv1alpha1.LocalDevice) (b
 			continue
 		}
 
-		lvm.logger.Debugf("Adding disk(s): %+v to pool %s", stringDevices(classifiedDisks), poolName)
+		lvm.logger.Debugf("Adding disk(s): %+v to pool %s", localDevicesArray(classifiedDisks).string(), poolName)
 		if err := lvm.extendPool(poolName, classifiedDisks); err != nil {
 			lvm.logger.WithError(err).Error("Add available disk failed.")
 			return extend, err
@@ -382,7 +393,7 @@ func (lvm *lvmExecutor) ExtendPools(localDevices []*apisv1alpha1.LocalDevice) (b
 }
 
 func (lvm *lvmExecutor) ResizePhysicalVolumes(localDevices map[string]*apisv1alpha1.LocalDevice) error {
-	lvm.logger.Debugf("Resizing pvsize, device(s): %+v, count: %d\n", localDevices, len(localDevices))
+	lvm.logger.Debugf("Resizing pvsize, device(s): %+v, count: %d", localDevicesMap(localDevices).string(), len(localDevices))
 
 	for _, disk := range localDevices {
 		if err := lvm.pvresize(disk.DevPath); err != nil {

--- a/pkg/local-storage/member/node/storage/pools.go
+++ b/pkg/local-storage/member/node/storage/pools.go
@@ -28,6 +28,10 @@ func (mgr *localPoolManager) GetReplicas() (map[string]*apisv1alpha1.LocalVolume
 	return mgr.cmdExec.GetReplicas()
 }
 
+func (mgr *localPoolManager) ResizePhysicalVolumes(localDisks map[string]*apisv1alpha1.LocalDevice) error {
+	return mgr.cmdExec.ResizePhysicalVolumes(localDisks)
+}
+
 func newLocalPoolManager(lm *LocalManager) LocalPoolManager {
 	return &localPoolManager{
 		cmdExec: newLVMExecutor(lm),

--- a/pkg/local-storage/member/node/storage/types.go
+++ b/pkg/local-storage/member/node/storage/types.go
@@ -26,6 +26,8 @@ type LocalPoolManager interface {
 	ExtendPoolsInfo(localDisks map[string]*apisv1alpha1.LocalDevice) (map[string]*apisv1alpha1.LocalPool, error)
 
 	GetReplicas() (map[string]*apisv1alpha1.LocalVolumeReplica, error)
+
+	ResizePhysicalVolumes(localDisks map[string]*apisv1alpha1.LocalDevice) error
 }
 
 // LocalVolumeReplicaManager interface
@@ -88,4 +90,5 @@ type LocalPoolExecutor interface {
 	ExtendPools(localDisks []*apisv1alpha1.LocalDevice) (bool, error)
 	ExtendPoolsInfo(localDisks map[string]*apisv1alpha1.LocalDevice) (map[string]*apisv1alpha1.LocalPool, error)
 	GetReplicas() (map[string]*apisv1alpha1.LocalVolumeReplica, error)
+	ResizePhysicalVolumes(localDisks map[string]*apisv1alpha1.LocalDevice) error
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
to fix: https://github.com/hwameistor/hwameistor/issues/617
#### Special notes for your reviewer:
We **assume** that after the underlying disk capacity changes, `udev` events can be captured. 
This event drives the storage capacity adjustment.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
