### PR TITLE
ignore NotFound error according to FailurePolicy

### DIFF
--- a/pkg/webhook/config/config.go
+++ b/pkg/webhook/config/config.go
@@ -114,18 +114,7 @@ func CreateAdmissionConfig(caCert *bytes.Buffer) error {
 						Resources:   []string{"pods"},
 					},
 				}},
-				FailurePolicy: func() *admissionregistrationv1.FailurePolicyType {
-					var pt admissionregistrationv1.FailurePolicyType
-					switch failurePolicy {
-					case string(admissionregistrationv1.Fail):
-						pt = admissionregistrationv1.Fail
-					case string(admissionregistrationv1.Ignore):
-						pt = admissionregistrationv1.Ignore
-					default:
-						pt = admissionregistrationv1.Fail
-					}
-					return &pt
-				}(),
+				FailurePolicy: GetFailurePolicy(),
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
@@ -200,4 +189,18 @@ func ensureNameSpaceKeyExist(clientset *k8s.Clientset) error {
 	}
 
 	return nil
+}
+
+func GetFailurePolicy() *admissionregistrationv1.FailurePolicyType {
+	var pt admissionregistrationv1.FailurePolicyType
+	switch failurePolicy {
+	case string(admissionregistrationv1.Fail):
+		pt = admissionregistrationv1.Fail
+	case string(admissionregistrationv1.Ignore):
+		pt = admissionregistrationv1.Ignore
+	default:
+		pt = admissionregistrationv1.Fail
+	}
+
+	return &pt
 }

--- a/pkg/webhook/scheduler/mutate.go
+++ b/pkg/webhook/scheduler/mutate.go
@@ -3,6 +3,9 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"github.com/hwameistor/hwameistor/pkg/webhook/config"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"strings"
 	"sync"
@@ -110,11 +113,14 @@ func (p *patchSchedulerName) ResourceNeedHandle(req admission.AdmissionReview) (
 		}
 		ok, err := p.IsHwameiStorVolume(pod.GetNamespace(), volume.PersistentVolumeClaim.ClaimName)
 		if err != nil {
-			// fixme: add a option to control the action when pvc is not found
-			//if errors.IsNotFound(err) {
-			//	logrus.WithFields(logCtx).Info("skip mutate this pod, because of pvc or storageclass is not found, can't judge volume is hwameistor volume")
-			//	return false, nil
-			//}
+			// case1: if FailurePolicy == Ignore and the StorageClass is not found, skip mutate
+			if errors.IsNotFound(err) && *config.GetFailurePolicy() == admissionregistrationv1.Ignore {
+				logrus.WithFields(logCtx).Infof("skip mutate this pod, because of pvc or storageclass is not found"+
+					"and FailurePolicy now is %s can't judge volume is hwameistor volume", admissionregistrationv1.Ignore)
+				return false, nil
+			}
+
+			// default: reject!
 			logrus.WithFields(logCtx).WithError(err).Error("failed to judge volume is hwameistor volume or not")
 			return false, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Skip `NotFound` error when StorageClass has't been created according to `FailurePolicy`.
fix https://github.com/hwameistor/hwameistor/issues/660

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
