### PR TITLE
Feat: Support specify disk owner

### DIFF
--- a/deploy/crds/hwameistor.io_localdiskclaims_crd.yaml
+++ b/deploy/crds/hwameistor.io_localdiskclaims_crd.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .status.status
       name: Phase
       type: string
+    - jsonPath: .spec.owner
+      name: Owner
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -40,11 +43,6 @@ spec:
           spec:
             description: LocalDiskClaimSpec defines the desired state of LocalDiskClaim
             properties:
-              consumed:
-                description: Consumed represents disks backing the claim has been
-                  already consumed by a consumer. If true the claim will be deleted
-                  soon from kubernetes
-                type: boolean
               description:
                 description: Description of the disk to be claimed
                 properties:
@@ -123,6 +121,10 @@ spec:
               nodeName:
                 description: NodeName represents where disk has to be claimed.
                 type: string
+              owner:
+                description: Owner represents which system owns this claim(e.g. local-storage,
+                  local-disk-manager)
+                type: string
             required:
             - nodeName
             type: object
@@ -135,6 +137,7 @@ spec:
                 - Bound
                 - Pending
                 - Extending
+                - Consumed
                 - ToBeDeleted
                 - Deleted
                 type: string

--- a/deploy/crds/hwameistor.io_localdisks_crd.yaml
+++ b/deploy/crds/hwameistor.io_localdisks_crd.yaml
@@ -17,8 +17,8 @@ spec:
     - jsonPath: .spec.nodeName
       name: NodeMatch
       type: string
-    - jsonPath: .spec.claimRef.name
-      name: Claim
+    - jsonPath: .spec.owner
+      name: Owner
       priority: 1
       type: string
     - jsonPath: .status.claimState
@@ -141,6 +141,10 @@ spec:
                 type: boolean
               nodeName:
                 description: NodeName represents the node where the disk is attached
+                type: string
+              owner:
+                description: Owner represents which system owns this claim(e.g. local-storage,
+                  local-disk-manager)
                 type: string
               partitionInfo:
                 description: PartitionInfo contains partition information

--- a/deploy/crds/hwameistor.io_localstoragenodes_crd.yaml
+++ b/deploy/crds/hwameistor.io_localstoragenodes_crd.yaml
@@ -105,11 +105,6 @@ spec:
                   items:
                     description: LocalDiskClaimSpec defines the desired state of LocalDiskClaim
                     properties:
-                      consumed:
-                        description: Consumed represents disks backing the claim has
-                          been already consumed by a consumer. If true the claim will
-                          be deleted soon from kubernetes
-                        type: boolean
                       description:
                         description: Description of the disk to be claimed
                         properties:
@@ -193,6 +188,10 @@ spec:
                         type: array
                       nodeName:
                         description: NodeName represents where disk has to be claimed.
+                        type: string
+                      owner:
+                        description: Owner represents which system owns this claim(e.g.
+                          local-storage, local-disk-manager)
                         type: string
                     required:
                     - nodeName

--- a/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
@@ -195,6 +195,10 @@ type LocalDiskSpec struct {
 	// Reserved represents the disk won't be used in hwameistor later, until it becomes unreserved
 	// +optional
 	Reserved bool `json:"reserved,omitempty"`
+
+	// Owner represents which system owns this claim(e.g. local-storage, local-disk-manager)
+	// +optional
+	Owner string `json:"owner,omitempty"`
 }
 
 // LocalDiskStatus defines the observed state of LocalDisk
@@ -212,7 +216,7 @@ type LocalDiskStatus struct {
 //+kubebuilder:resource:scope=Cluster,shortName=ld
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:JSONPath=".spec.nodeName",name=NodeMatch,type=string
-//+kubebuilder:printcolumn:JSONPath=".spec.claimRef.name",name=Claim,type=string,priority=1
+//+kubebuilder:printcolumn:JSONPath=".spec.owner",name=Owner,type=string,priority=1
 //+kubebuilder:printcolumn:JSONPath=".status.claimState",name=Phase,type=string
 //+kubebuilder:printcolumn:JSONPath=".spec.smartInfo.overallHealth",name=Health,type=string,priority=1
 //+kubebuilder:printcolumn:JSONPath=".spec.reserved",name=Reserved,type=boolean,priority=1

--- a/pkg/apis/hwameistor/v1alpha1/localdiskclaim_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localdiskclaim_types.go
@@ -22,10 +22,8 @@ type LocalDiskClaimSpec struct {
 	// +optional
 	DiskRefs []*v1.ObjectReference `json:"diskRefs,omitempty"`
 
-	// Consumed represents disks backing the claim has been already consumed by a consumer.
-	// If true the claim will be deleted soon from kubernetes
-	// +optional
-	Consumed bool `json:"consumed,omitempty"`
+	// Owner represents which system owns this claim(e.g. local-storage, local-disk-manager)
+	Owner string `json:"owner,omitempty"`
 }
 
 type LocalDiskClaimSpecArray []LocalDiskClaimSpec
@@ -33,7 +31,7 @@ type LocalDiskClaimSpecArray []LocalDiskClaimSpec
 // LocalDiskClaimStatus defines the observed state of LocalDiskClaim
 type LocalDiskClaimStatus struct {
 	// Status represents the current statue of the claim
-	// +kubebuilder:validation:Enum:=Bound;Pending;Extending;ToBeDeleted;Deleted
+	// +kubebuilder:validation:Enum:=Bound;Pending;Extending;Consumed;ToBeDeleted;Deleted
 	Status DiskClaimStatus `json:"status,omitempty"`
 }
 
@@ -46,6 +44,7 @@ type LocalDiskClaimStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:JSONPath=".spec.nodeName",name=NodeMatch,type=string
 //+kubebuilder:printcolumn:JSONPath=".status.status",name=Phase,type=string
+//+kubebuilder:printcolumn:JSONPath=".spec.owner",name=Owner,type=string
 //+kubebuilder:resource:scope=Cluster,shortName=ldc
 type LocalDiskClaim struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -92,6 +91,9 @@ const (
 
 	// LocalDiskClaimStatusBound represents LocalDiskClaim has been assigned backing disk and ready for use.
 	LocalDiskClaimStatusBound DiskClaimStatus = "Bound"
+
+	// LocalDiskClaimStatusConsumed represents disks backing this LocalDiskClaim is consumed by the consumer
+	LocalDiskClaimStatusConsumed DiskClaimStatus = "Consumed"
 
 	// LocalDiskClaimStatusToBeDeleted represents disks backing this LocalDiskClaim is consumed already and the claim
 	// will be deleted after some clean job done

--- a/pkg/local-disk-manager/controller/localdisk/localdisk_controller.go
+++ b/pkg/local-disk-manager/controller/localdisk/localdisk_controller.go
@@ -154,8 +154,8 @@ func (r *ReconcileLocalDisk) processDiskAvailable(disk *v1alpha1.LocalDisk) erro
 	logCtx := log.Fields{"name": disk.Name}
 	log.WithFields(logCtx).Info("Start to processing Available localdisk")
 
-	// Update disk status if found partition or filesystem or diskRed on it
-	if disk.Spec.HasPartition || disk.Spec.ClaimRef != nil {
+	// Update disk status if found partition or filesystem or diskRed or owner on it
+	if disk.Spec.HasPartition || disk.Spec.ClaimRef != nil || disk.Spec.Owner != "" {
 		return r.updateDiskStatusBound(disk)
 	}
 
@@ -167,12 +167,9 @@ func (r *ReconcileLocalDisk) processDiskBound(disk *v1alpha1.LocalDisk) error {
 	logCtx := log.Fields{"name": disk.Name}
 	log.WithFields(logCtx).Info("Start to processing Bound localdisk")
 
-	var (
-		err error
-	)
-
+	var err error
 	// Check if disk can be released
-	if disk.Spec.ClaimRef == nil && !disk.Spec.HasPartition {
+	if disk.Spec.ClaimRef == nil && !disk.Spec.HasPartition && disk.Spec.Owner == "" {
 		if err = r.updateDiskStatusAvailable(disk); err != nil {
 			log.WithError(err).WithFields(logCtx).Error("Failed to release disk")
 			r.Recorder.Eventf(disk, v1.EventTypeWarning, v1alpha1.LocalDiskEventReasonReleaseFail,

--- a/pkg/local-disk-manager/controller/localdisk/localdisk_controller.go
+++ b/pkg/local-disk-manager/controller/localdisk/localdisk_controller.go
@@ -154,8 +154,8 @@ func (r *ReconcileLocalDisk) processDiskAvailable(disk *v1alpha1.LocalDisk) erro
 	logCtx := log.Fields{"name": disk.Name}
 	log.WithFields(logCtx).Info("Start to processing Available localdisk")
 
-	// Update disk status if found partition or filesystem or diskRed or owner on it
-	if disk.Spec.HasPartition || disk.Spec.ClaimRef != nil || disk.Spec.Owner != "" {
+	// Update disk status if found partition or filesystem or diskRed on it
+	if disk.Spec.HasPartition || disk.Spec.ClaimRef != nil {
 		return r.updateDiskStatusBound(disk)
 	}
 

--- a/pkg/local-disk-manager/controller/localdiskclaim/localdiskclaim_controller.go
+++ b/pkg/local-disk-manager/controller/localdiskclaim/localdiskclaim_controller.go
@@ -94,6 +94,8 @@ func (r *ReconcileLocalDiskClaim) Reconcile(_ context.Context, req reconcile.Req
 		err = r.processDiskClaimPending(diskClaim)
 	case v1alpha1.LocalDiskClaimStatusBound:
 		err = r.processDiskClaimBound(diskClaim)
+	case v1alpha1.LocalDiskClaimStatusConsumed:
+		err = r.processDiskClaimConsumed(diskClaim)
 	case v1alpha1.LocalDiskClaimStatusToBeDeleted:
 		err = r.processDiskClaimToBeDeleted(diskClaim)
 	case v1alpha1.LocalDiskClaimStatusDeleted:
@@ -157,13 +159,13 @@ func (r *ReconcileLocalDiskClaim) processDiskClaimBound(diskClaim *v1alpha1.Loca
 		return r.diskClaimHandler.UpdateClaimStatus()
 	}
 
-	// Update claim.status to ToBeDeleted if disks backing this claim have been consumed
-	if diskClaim.Spec.Consumed {
-		r.diskClaimHandler.SetupClaimStatus(v1alpha1.LocalDiskClaimStatusToBeDeleted)
-		return r.diskClaimHandler.UpdateClaimStatus()
-	}
-
 	return nil
+}
+
+func (r *ReconcileLocalDiskClaim) processDiskClaimConsumed(_ *v1alpha1.LocalDiskClaim) error {
+	// Update claim.status to ToBeDeleted if disks backing this claim have been consumed
+	r.diskClaimHandler.SetupClaimStatus(v1alpha1.LocalDiskClaimStatusToBeDeleted)
+	return r.diskClaimHandler.UpdateClaimStatus()
 }
 
 func (r *ReconcileLocalDiskClaim) processDiskClaimToBeDeleted(diskClaim *v1alpha1.LocalDiskClaim) error {

--- a/pkg/local-disk-manager/filter/filter_disk.go
+++ b/pkg/local-disk-manager/filter/filter_disk.go
@@ -113,7 +113,8 @@ func (ld *LocalDiskFilter) NoPartition() *LocalDiskFilter {
 }
 
 func (ld *LocalDiskFilter) OwnerMatch(owner string) *LocalDiskFilter {
-	if ld.localDisk.Spec.Owner == "" || ld.localDisk.Spec.Owner == owner {
+	if (ld.localDisk.Spec.Owner == "" && owner == "local-storage") /* Only for local-storage */ ||
+		ld.localDisk.Spec.Owner == owner {
 		ld.setResult(TRUE)
 	} else {
 		ld.setResult(FALSE)

--- a/pkg/local-disk-manager/filter/filter_disk.go
+++ b/pkg/local-disk-manager/filter/filter_disk.go
@@ -112,6 +112,16 @@ func (ld *LocalDiskFilter) NoPartition() *LocalDiskFilter {
 	return ld
 }
 
+func (ld *LocalDiskFilter) OwnerMatch(owner string) *LocalDiskFilter {
+	if ld.localDisk.Spec.Owner == "" || ld.localDisk.Spec.Owner == owner {
+		ld.setResult(TRUE)
+	} else {
+		ld.setResult(FALSE)
+	}
+
+	return ld
+}
+
 // HasBoundWith indicates disk has already bound with the claim
 // https://github.com/hwameistor/hwameistor/issues/315
 func (ld *LocalDiskFilter) HasBoundWith(claimName string) bool {

--- a/pkg/local-disk-manager/handler/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk.go
@@ -174,6 +174,7 @@ func (ldHandler *Handler) FilterDisk(ldc *v1alpha1.LocalDiskClaim) bool {
 		Init().
 		Available().
 		HasNotReserved().
+		OwnerMatch(ldc.Spec.Owner).
 		NodeMatch(ldc.Spec.NodeName).
 		Capacity(ldc.Spec.Description.Capacity).
 		DiskType(ldc.Spec.Description.DiskType).

--- a/pkg/local-disk-manager/handler/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk.go
@@ -116,6 +116,7 @@ func (ldHandler *Handler) BoundTo(ldc *v1alpha1.LocalDiskClaim) error {
 	// Update the disk.spec.ClaimRef field to indicate that the disk is claimed
 	ldcRef, _ := reference.GetReference(nil, ldc)
 	ldHandler.localDisk.Spec.ClaimRef = ldcRef
+	ldHandler.localDisk.Spec.Owner = ldc.Spec.Owner
 
 	err := ldHandler.Update()
 	if err == nil {

--- a/pkg/local-storage/member/node/local_disk_claim_task_worker.go
+++ b/pkg/local-storage/member/node/local_disk_claim_task_worker.go
@@ -287,6 +287,6 @@ func (m *manager) getLocalDiskByName(localDiskName, nameSpace string) (*apisv1al
 
 func (m *manager) updateDiskClaimConsumed(claim *apisv1alpha1.LocalDiskClaim) error {
 	oldClaim := claim.DeepCopy()
-	claim.Spec.Consumed = true
-	return m.apiClient.Patch(context.Background(), claim, client.MergeFrom(oldClaim))
+	claim.Status.Status = apisv1alpha1.LocalDiskClaimStatusConsumed
+	return m.apiClient.Status().Patch(context.Background(), claim, client.MergeFrom(oldClaim))
 }

--- a/pkg/local-storage/member/node/manager.go
+++ b/pkg/local-storage/member/node/manager.go
@@ -35,7 +35,8 @@ import (
 //
 // Infinitely retry
 const (
-	maxRetries = 0
+	maxRetries   = 0
+	localStorage = "local-storage"
 )
 
 type manager struct {
@@ -394,7 +395,7 @@ func (m *manager) handleVolumeReplicaDelete(obj interface{}) {
 
 func (m *manager) handleLocalDiskClaimUpdate(oldObj, newObj interface{}) {
 	localDiskClaim, _ := newObj.(*apisv1alpha1.LocalDiskClaim)
-	if !(localDiskClaim.Spec.NodeName == m.name && !localDiskClaim.Spec.Consumed &&
+	if !(localDiskClaim.Spec.NodeName == m.name && localDiskClaim.Spec.Owner == localStorage &&
 		localDiskClaim.Status.Status == apisv1alpha1.LocalDiskClaimStatusBound) {
 		return
 	}
@@ -403,7 +404,7 @@ func (m *manager) handleLocalDiskClaimUpdate(oldObj, newObj interface{}) {
 
 func (m *manager) handleLocalDiskClaimAdd(obj interface{}) {
 	localDiskClaim, _ := obj.(*apisv1alpha1.LocalDiskClaim)
-	if !(localDiskClaim.Spec.NodeName == m.name && !localDiskClaim.Spec.Consumed &&
+	if !(localDiskClaim.Spec.NodeName == m.name && localDiskClaim.Spec.Owner == localStorage &&
 		localDiskClaim.Status.Status == apisv1alpha1.LocalDiskClaimStatusBound) {
 		return
 	}
@@ -412,7 +413,8 @@ func (m *manager) handleLocalDiskClaimAdd(obj interface{}) {
 
 func (m *manager) handleLocalDiskUpdate(oldObj, newObj interface{}) {
 	localDisk, _ := newObj.(*apisv1alpha1.LocalDisk)
-	if !(localDisk.Spec.NodeName == m.name && localDisk.Status.State == apisv1alpha1.LocalDiskBound) {
+	if !(localDisk.Spec.NodeName == m.name && localDisk.Spec.Owner == localStorage &&
+		localDisk.Status.State == apisv1alpha1.LocalDiskBound) {
 		return
 	}
 	m.localDiskTaskQueue.Add(localDisk.Namespace + "/" + localDisk.Name)
@@ -420,7 +422,8 @@ func (m *manager) handleLocalDiskUpdate(oldObj, newObj interface{}) {
 
 func (m *manager) handleLocalDiskAdd(newObj interface{}) {
 	localDisk, _ := newObj.(*apisv1alpha1.LocalDisk)
-	if !(localDisk.Spec.NodeName == m.name && localDisk.Status.State == apisv1alpha1.LocalDiskBound) {
+	if !(localDisk.Spec.NodeName == m.name && localDisk.Spec.Owner == localStorage &&
+		localDisk.Status.State == apisv1alpha1.LocalDiskBound) {
 		return
 	}
 	m.localDiskTaskQueue.Add(localDisk.Namespace + "/" + localDisk.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
To support custom storage system use disks by `LocalDiskClaim`
#### Special notes for your reviewer:

##### How to use?

1.  Apply LocalDiskClaim and specify its owner (**For admin**)
```shell
$ cat << EOF | kubectl apply  -f -
apiVersion: hwameistor.io/v1alpha1
kind: LocalDiskClaim
metadata:
  name: localdiskclaim-sample
spec:
  nodeName: 172-30-46-10
  owner: local-storage
  description:
    diskType: HDD
EOF
```

2. Watch and `consume` the LocalDiskClaim when its status is `Bound` (**For owner**)
```
your logic here in code
```

3. Update status to `Consumed` when disk backing the LocalDiskClaim is consumed(**For owner**)
```
your logic here in code
```

4. Observe the LocalDiskClaim and it will be `deleted` soon (**For admin**)
```
$ kubectl get ldc localdiskclaim-sample -w
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
See above
```
