### PR TITLE
use NewClientBuilder instead of the deprecated NewFakeClientWithScheme

### DIFF
--- a/pkg/local-disk-manager/controller/localdisk/localdisk_controller_test.go
+++ b/pkg/local-disk-manager/controller/localdisk/localdisk_controller_test.go
@@ -142,7 +142,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, diskList)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, claim)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, claimList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }
 
 // GenFakeLocalDiskObject Create disk

--- a/pkg/local-disk-manager/controller/localdiskclaim/localdiskclaim_controller_test.go
+++ b/pkg/local-disk-manager/controller/localdiskclaim/localdiskclaim_controller_test.go
@@ -395,5 +395,5 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, diskList)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, claim)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, claimList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }

--- a/pkg/local-disk-manager/controller/localdisknode/localdisknode_controller_test.go
+++ b/pkg/local-disk-manager/controller/localdisknode/localdisknode_controller_test.go
@@ -216,7 +216,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskList{})
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskNode{})
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskNodeList{})
-	return fake.NewFakeClientWithScheme(s, &v1alpha1.LocalDisk{}, &v1alpha1.LocalDiskNode{}), s
+	return fake.NewClientBuilder().WithScheme(s).WithObjects(&v1alpha1.LocalDisk{}, &v1alpha1.LocalDiskNode{}).Build(), s
 }
 
 // GenFakeLocalDiskObject Create disk

--- a/pkg/local-disk-manager/handler/localdisk/localdisk_test.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk_test.go
@@ -130,7 +130,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskList{})
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskNode{})
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskNodeList{})
-	return fake.NewFakeClientWithScheme(s, &v1alpha1.LocalDisk{}, &v1alpha1.LocalDiskNode{}), s
+	return fake.NewClientBuilder().WithScheme(s).WithObjects(&v1alpha1.LocalDisk{}, &v1alpha1.LocalDiskNode{}).Build(), s
 }
 
 // GenFakeLocalDiskObject Create disk

--- a/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim_test.go
+++ b/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim_test.go
@@ -242,7 +242,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskNodeList{})
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskClaim{})
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.LocalDiskClaimList{})
-	return fake.NewFakeClientWithScheme(s, &v1alpha1.LocalDisk{}, &v1alpha1.LocalDiskNode{}), s
+	return fake.NewClientBuilder().WithScheme(s).WithObjects(&v1alpha1.LocalDisk{}, &v1alpha1.LocalDiskNode{}).Build(), s
 }
 
 // GenFakeLocalDiskObject Create disk

--- a/pkg/local-storage/controller/localstoragenode/localstoragenode_controller_test.go
+++ b/pkg/local-storage/controller/localstoragenode/localstoragenode_controller_test.go
@@ -156,5 +156,5 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s := scheme.Scheme
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lsn)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lsnList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }

--- a/pkg/local-storage/controller/localvolume/localvolume_controller_test.go
+++ b/pkg/local-storage/controller/localvolume/localvolume_controller_test.go
@@ -169,7 +169,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s := scheme.Scheme
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lv)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lvList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }
 
 func validateSystemConfig() error {

--- a/pkg/local-storage/controller/localvolumeconvert/localvolumeconvert_controller_test.go
+++ b/pkg/local-storage/controller/localvolumeconvert/localvolumeconvert_controller_test.go
@@ -152,5 +152,5 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s := scheme.Scheme
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lsn)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lsnList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }

--- a/pkg/local-storage/controller/localvolumeexpand/localvolumeexpand_controller_test.go
+++ b/pkg/local-storage/controller/localvolumeexpand/localvolumeexpand_controller_test.go
@@ -152,5 +152,5 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s := scheme.Scheme
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lsn)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lsnList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }

--- a/pkg/local-storage/controller/localvolumegroup/localvolumegroup_controller_test.go
+++ b/pkg/local-storage/controller/localvolumegroup/localvolumegroup_controller_test.go
@@ -149,7 +149,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s := scheme.Scheme
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lvg)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lvgList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }
 
 func validateSystemConfig() error {

--- a/pkg/local-storage/controller/localvolumemigrate/localvolumemigrate_controller_test.go
+++ b/pkg/local-storage/controller/localvolumemigrate/localvolumemigrate_controller_test.go
@@ -215,7 +215,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lvgList)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lv)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lvList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }
 
 // GenFakeLocalVolumeGroupMigrateObject Create lvgm request

--- a/pkg/local-storage/controller/localvolumereplica/localvolumereplica_controller_test.go
+++ b/pkg/local-storage/controller/localvolumereplica/localvolumereplica_controller_test.go
@@ -145,7 +145,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s := scheme.Scheme
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lv)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, lvList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }
 
 func validateSystemConfig() error {

--- a/pkg/local-storage/member/controller/scheduler/resources_test.go
+++ b/pkg/local-storage/member/controller/scheduler/resources_test.go
@@ -705,7 +705,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, lvList)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, lsn)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, lsnList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }
 
 func Test_resources_predicate(t *testing.T) {

--- a/pkg/local-storage/member/controller/volume_task_worker_test.go
+++ b/pkg/local-storage/member/controller/volume_task_worker_test.go
@@ -441,7 +441,7 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, lsnList)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, lease)
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, leaseList)
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }
 
 func Test_manager_processVolume(t *testing.T) {

--- a/pkg/local-storage/member/node/volume_task_worker_test.go
+++ b/pkg/local-storage/member/node/volume_task_worker_test.go
@@ -755,5 +755,5 @@ func CreateFakeClient() (client.Client, *runtime.Scheme) {
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, ldc)
 	s.AddKnownTypes(apisv1alpha1.SchemeGroupVersion, ldcList)
 
-	return fake.NewFakeClientWithScheme(s), s
+	return fake.NewClientBuilder().WithScheme(s).Build(), s
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

The `NewFakeClientWithScheme` will be deprecated and `NewClientBuilder` will be used instead

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
