### PR TITLE
set drbdStartPort 43001

### DIFF
--- a/helm/hwameistor/values.yaml
+++ b/helm/hwameistor/values.yaml
@@ -109,11 +109,9 @@ localStorage:
     config:
       # Each HA volume using DRBD will occupy a port for data volume synchronization.
       # hwameistor limits each node to use up to 1000 volumes, so the final port range is [ startPort, startPort + maxHAVolumeCount - 1 ].
-      # default value: 43001
-      drbdStartPort:
+      drbdStartPort: 43001
       # Max HA volume count
-      # default value: 1000
-      maxHAVolumeCount:
+      maxHAVolumeCount: 1000
     imageRepository: hwameistor/local-storage
     tag: ""
     resources: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Specify the starting port and maximum number of data volumes for DRBD

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
