### PR TITLE
populate disk owner when empty

### DIFF
--- a/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
@@ -8,6 +8,11 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	LocalStorage = "local-storage"
+	System       = "system"
+)
+
 // PartitionInfo contains partition information(e.g. FileSystem)
 type PartitionInfo struct {
 	// Path represents the partition path in the OS

--- a/pkg/local-disk-manager/handler/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk.go
@@ -194,3 +194,17 @@ func (ldHandler *Handler) RecordEvent(eventtype, reason, messageFmt string, args
 func (ldHandler *Handler) SetPartition(hasPartition bool) {
 	ldHandler.localDisk.Spec.HasPartition = hasPartition
 }
+
+func (ldHandler *Handler) SetOwner(owner string) {
+	ldHandler.localDisk.Spec.Owner = owner
+}
+
+func (ldHandler *Handler) PatchDiskOwner(owner string) error {
+	oldDisk := ldHandler.localDisk.DeepCopy()
+	ldHandler.SetOwner(owner)
+	return ldHandler.PatchDiskSpec(client.MergeFrom(oldDisk))
+}
+
+func (ldHandler *Handler) PatchDiskSpec(patch client.Patch) error {
+	return ldHandler.Client.Patch(context.Background(), ldHandler.localDisk, patch)
+}

--- a/pkg/local-disk-manager/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/localdisk/localdisk.go
@@ -96,6 +96,7 @@ func (ctr Controller) mergerLocalDisk(oldLd v1alpha1.LocalDisk, newLd *v1alpha1.
 	newLd.TypeMeta = oldLd.TypeMeta
 	newLd.ObjectMeta = oldLd.ObjectMeta
 	newLd.Spec.ClaimRef = oldLd.Spec.ClaimRef
+	newLd.Spec.Owner = oldLd.Spec.Owner
 }
 
 func (ctr Controller) GenLocalDiskName(disk manager.DiskInfo) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Populate disk `owner` info during usage phase.

#### Special notes for your reviewer:
We only find disks known by our system, if disks managed by the other system we just show its owner as `system`.

Samples:
```shell
[root@172-30-46-10 ~]# kubectl get ld -o wide
NAME                NODEMATCH      OWNER           PHASE   HEALTH   RESERVED
172-30-46-10-sda    172-30-46-10   system          Bound   Passed
172-30-46-10-sdaa   172-30-46-10   local-storage   Bound   Passed
172-30-46-10-sdab   172-30-46-10   local-storage   Bound   Passed
172-30-46-10-sdb    172-30-46-10   local-storage   Bound   Passed
172-30-46-10-sdc    172-30-46-10   local-storage   Bound   Passed
172-30-46-10-sdd    172-30-46-10   local-storage   Bound   Passed
172-30-46-10-sde    172-30-46-10   local-storage   Bound   Passed
172-30-46-10-sdf    172-30-46-10   local-storage   Bound   Passed
172-30-46-10-sdg    172-30-46-10   system          Bound   Passed
172-30-46-10-sdh    172-30-46-10   local-storage   Bound   Passed
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
