### PR TITLE
recognize and setup disks managed by local-disk-manager owner

### DIFF
--- a/pkg/local-disk-manager/member/node/registry/internal.go
+++ b/pkg/local-disk-manager/member/node/registry/internal.go
@@ -13,6 +13,11 @@ import (
 	"sync"
 )
 
+var (
+	registry Manager
+	once     sync.Once
+)
+
 type localRegistry struct {
 	// disks storage node disks managed by LocalDiskManager
 	// index by disk name
@@ -37,9 +42,14 @@ type localRegistry struct {
 }
 
 func New() Manager {
-	return &localRegistry{
-		hu: hostutil.NewHostUtil(),
-	}
+	once.Do(func() {
+		registry = &localRegistry{
+			hu: hostutil.NewHostUtil(),
+		}
+		// discovery resources immediately
+		registry.DiscoveryResources()
+	})
+	return registry
 }
 
 // DiscoveryResources discovery disks and volumes


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Support recognize and setup disks managed by local-disk-manager owner

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
