### PR TITLE
list storagepool createtime field inconsistent

### DIFF
--- a/pkg/apiserver/manager/hwameistor/localstoragepool_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragepool_controller.go
@@ -95,7 +95,7 @@ func (lspController *LocalStoragePoolController) makeStoragePoolNodesCollectionM
 		return nil, err
 	}
 	sort.Slice(lsnList.Items, func(i, j int) bool {
-		return lsnList.Items[i].CreationTimestamp.String() > lsnList.Items[j].CreationTimestamp.String()
+		return lsnList.Items[i].CreationTimestamp.After(lsnList.Items[j].CreationTimestamp.Time)
 	})
 
 	var storagePoolNodesCollectionMap = make(map[string]*hwameistorapi.StoragePoolNodesCollection)

--- a/pkg/apiserver/manager/hwameistor/localstoragepool_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragepool_controller.go
@@ -3,6 +3,7 @@ package hwameistor
 import (
 	"context"
 	"math"
+	"sort"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -93,6 +94,9 @@ func (lspController *LocalStoragePoolController) makeStoragePoolNodesCollectionM
 		log.WithError(err).Error("Failed to list LocalStorageNodes")
 		return nil, err
 	}
+	sort.Slice(lsnList.Items, func(i, j int) bool {
+		return lsnList.Items[i].CreationTimestamp.String() > lsnList.Items[j].CreationTimestamp.String()
+	})
 
 	var storagePoolNodesCollectionMap = make(map[string]*hwameistorapi.StoragePoolNodesCollection)
 	for _, lsn := range lsnList.Items {


### PR DESCRIPTION
#### What this PR does / why we need it:

the create time field is inconsistent when querying the storage pool list

#### Special notes for your reviewer:

When multiple requests are made to obtain the storage pool list interface, the create time is inconsistent

#### Does this PR introduce a user-facing change?
yes
```release-note
fix the create time field is inconsistent when querying the storage pool list
```
