### PR TITLE
Use */virtual/* detection for identifying virtual block devices

### DIFF
--- a/pkg/local-disk-manager/udev/device.go
+++ b/pkg/local-disk-manager/udev/device.go
@@ -32,7 +32,7 @@ func (d CDevice) FilterDisk() bool {
 	log.Debugf("Device info in udev is:%+v", *device)
 
 	// virtual block device like loop device will be filter out
-	if device.IDPath == "" {
+	if strings.Contains(device.DevPath, "/virtual/") {
 		return false
 	}
 
@@ -85,9 +85,6 @@ type Device struct {
 
 	// ID_TYPE
 	IDType string `json:"id_type"`
-
-	// ID_PATH
-	IDPath string `json:"id_path"`
 
 	// PartName such as EFI System Partition
 	PartName string `json:"partName"`


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR alters the way virtual block devices are detected.
Detecting /virtual/ in the DEVPATH attribute is the way udev uses by default to check if a id_path attribute should be added. 

This allows hwameistor to work even if path_id is disabled in udev.

#### Special notes for your reviewer:
See also: https://github.com/eudev-project/eudev/blob/master/rules/60-persistent-storage.rules#L90

#### Does this PR introduce a user-facing change?
NONE

```release-note
Allow hwameistor to work even if id_path is not set by udev
```
