### PR TITLE
Fix scheduler config template, made hostpaths configurable in Helm Chart

### DIFF
--- a/helm/hwameistor/templates/local-storage.yaml
+++ b/helm/hwameistor/templates/local-storage.yaml
@@ -176,7 +176,7 @@ spec:
           type: ""
         name: host-dev
       - hostPath:
-          path: /etc/drbd.d
+          path: {{ .Values.localStorage.hostPaths.drbdDir }}
           type: DirectoryOrCreate
         name: host-etc-drbd
       - hostPath:
@@ -184,7 +184,7 @@ spec:
           type: DirectoryOrCreate
         name: pods-mount-dir
       - hostPath:
-          path: /root/.ssh
+          path: {{ .Values.localStorage.hostPaths.sshDir }}
           type: DirectoryOrCreate
         name: ssh-dir
       - hostPath:

--- a/helm/hwameistor/templates/scheduler-config.yaml
+++ b/helm/hwameistor/templates/scheduler-config.yaml
@@ -2,12 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hwameistor-scheduler-config
-  namespace: {{ .Release.Namespace}}
-data:
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: hwameistor-scheduler-config
   namespace: {{ .Release.Namespace }}
 data:
   hwameistor-scheduler-config.yaml: |

--- a/helm/hwameistor/values.yaml
+++ b/helm/hwameistor/values.yaml
@@ -125,6 +125,9 @@ localStorage:
       # can use daocloud.io/daocloud/hwameistor-migrate-rclone:v1.1.2 which is exactly same as the following
       imageRepository: rclone/rclone
       tag: 1.53.2
+  hostPaths:
+    sshDir: /root/.ssh
+    drbdDir: /etc/drbd.d
 
 localStorageCSIController:
   replicas: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes the usage of Kustomize by removing (potentially by mistake) double defined keys in the Helm template. While Helm generally doesn't have a problem with double definitions, other systems do.

It also makes the hostpaths configurable which allows hwameistor to run on mostly read-only distributions like Talos Linux 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add configurable hostpaths to local-storage Helm chart
Fix Helm-Chart usage with Kustomize
```
