### PR TITLE
Use syscall instead of df to gather volume stats

### DIFF
--- a/pkg/local-storage/member/csi/utils.go
+++ b/pkg/local-storage/member/csi/utils.go
@@ -3,14 +3,11 @@ package csi
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
+	"syscall"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/gofrs/uuid"
-
-	"github.com/hwameistor/hwameistor/pkg/exechelper"
-	"github.com/hwameistor/hwameistor/pkg/exechelper/nsexecutor"
 )
 
 func newControllerServiceCapability(cap csi.ControllerServiceCapability_RPC_Type) *csi.ControllerServiceCapability {
@@ -66,85 +63,24 @@ func pathExists(path string) (bool, error) {
 }
 
 func getVolumeMetrics(mntPoint string) (*VolumeMetrics, error) {
-	headers := []string{
-		"Inodes",
-		"IFree",
-		"IUsed",
-		"1B-blocks",
-		"Avail",
-		"Used",
-	}
-	dfFlags := []string{
-		"--sync",
-		"--block-size=1",
-		"--output=itotal,iavail,iused,size,avail,used",
-		mntPoint,
-	}
-	dfPath := "df"
+	var stats syscall.Statfs_t
 
-	res := nsexecutor.New().RunCommand(exechelper.ExecParams{
-		CmdName: dfPath,
-		CmdArgs: dfFlags,
-	})
+	syscall.Sync()
 
-	if res.ExitCode != 0 {
-		return nil, res.Error
-	}
-	if res.OutBuf == nil {
-		return nil, fmt.Errorf("no output")
+	err := syscall.Statfs(mntPoint, &stats)
+
+	if err != nil {
+		return nil, err
 	}
 
-	for _, line := range strings.Split(res.OutBuf.String(), "\n") {
-		line = strings.TrimSpace(line)
-		// Skip for empty line or before header found.
-		if len(line) == 0 {
-			continue
-		}
-
-		if strings.Contains(line, headers[0]) {
-			// skip the header line
-			continue
-		}
-		// Split line into array
-		fields := strings.Fields(line)
-		if len(fields) != len(headers) {
-			return nil, fmt.Errorf("invalid output")
-		}
-		inodeTotal, err := strconv.ParseInt(fields[0], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		inodeFree, err := strconv.ParseInt(fields[1], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		inodeUsed, err := strconv.ParseInt(fields[2], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		capacityTotal, err := strconv.ParseInt(fields[3], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		capacityFree, err := strconv.ParseInt(fields[4], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		capacityUsed, err := strconv.ParseInt(fields[5], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		return &VolumeMetrics{
-			TotalCapacityBytes: capacityTotal,
-			UsedCapacityBytes:  capacityUsed,
-			FreeCapacityBytes:  capacityFree,
-			TotalINodeNumber:   inodeTotal,
-			UsedINodeNumber:    inodeUsed,
-			FreeINodeNumber:    inodeFree,
-		}, nil
-	}
-
-	return nil, fmt.Errorf("not found")
+	return &VolumeMetrics{
+		TotalCapacityBytes: int64(stats.Blocks * uint64(stats.Bsize)),
+		UsedCapacityBytes:  int64((stats.Blocks - stats.Bfree) * uint64(stats.Bsize)),
+		FreeCapacityBytes:  int64(stats.Bavail * uint64(stats.Bsize)),
+		TotalINodeNumber:   int64(stats.Files),
+		UsedINodeNumber:    int64(stats.Files - stats.Ffree),
+		FreeINodeNumber:    int64(stats.Ffree),
+	}, nil
 }
 
 func isStringInArray(str string, strs []string) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
This PR moves checking the volume stats (inodes, available blocks, etc) to a syscall - making it more resilient to changes in output due to different OSes and their df implementations. It also enables stats to work on systems which do not have df installed like Talos Linux

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
