### PR TITLE
Add cgroupsv2 support

### DIFF
--- a/pkg/local-storage/member/node/qos/cgroups.go
+++ b/pkg/local-storage/member/node/qos/cgroups.go
@@ -2,7 +2,8 @@ package qos
 
 import (
 	"fmt"
-	"os"
+	"github.com/hwameistor/hwameistor/pkg/exechelper"
+	"github.com/hwameistor/hwameistor/pkg/exechelper/nsexecutor"
 	"path/filepath"
 	"syscall"
 
@@ -26,11 +27,11 @@ func NewVolumeCgroupsManager() (VolumeCgroupsManager, error) {
 	mode := cgroups.Mode()
 	switch mode {
 	case cgroups.Legacy:
-		return &cgroupV1{}, nil
+		return &cgroupV1{nsexecutor.New()}, nil
 	case cgroups.Hybrid:
-		return &cgroupV2{hybridCGroupsIOLimits}, nil
+		return &cgroupV2{nsexecutor.New(), hybridCGroupsIOLimits}, nil
 	case cgroups.Unified:
-		return &cgroupV2{cgroupV2IOLimits}, nil
+		return &cgroupV2{nsexecutor.New(), cgroupV2IOLimits}, nil
 	case cgroups.Unavailable:
 		return &noop{}, fmt.Errorf("cgroups is not available")
 	}
@@ -40,7 +41,9 @@ func NewVolumeCgroupsManager() (VolumeCgroupsManager, error) {
 var _ VolumeCgroupsManager = &cgroupV1{}
 
 // cgroupV1 is the implementation of VolumeCgroupsManager for cgroup v1.
-type cgroupV1 struct{}
+type cgroupV1 struct {
+	exec exechelper.Executor
+}
 
 // ConfigureQoSForDevice configures the QoS for a volume.
 func (c *cgroupV1) ConfigureQoSForDevice(devPath string, iops, throughput int64) error {
@@ -50,25 +53,25 @@ func (c *cgroupV1) ConfigureQoSForDevice(devPath string, iops, throughput int64)
 	}
 
 	filename := filepath.Join(cgroupV1BlkioPath, "blkio.throttle.read_bps_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
 	if err != nil {
 		return err
 	}
 
 	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.write_bps_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
 	if err != nil {
 		return err
 	}
 
 	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.read_iops_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
 	if err != nil {
 		return err
 	}
 
 	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.write_iops_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
 	if err != nil {
 		return err
 	}
@@ -85,6 +88,7 @@ func (n *noop) ConfigureQoSForDevice(string, int64, int64) error {
 
 // cgroupV2 is the implementation of VolumeCgroupsManager for cgroup v2.
 type cgroupV2 struct {
+	exec         exechelper.Executor
 	iolimitsPath string
 }
 
@@ -96,7 +100,7 @@ func (c *cgroupV2) ConfigureQoSForDevice(devPath string, iops, throughput int64)
 	}
 
 	filename := filepath.Join(c.iolimitsPath)
-	err = writeFile(filename, fmt.Sprintf("%d:%d rbps=%d wbps=%d riops=%d wiops=%d", major, minor, throughput, throughput, iops, iops))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d rbps=%d wbps=%d riops=%d wiops=%d", major, minor, throughput, throughput, iops, iops))
 	if err != nil {
 		return err
 	}
@@ -116,18 +120,10 @@ func getDeviceNumber(devicePath string) (uint64, uint64, error) {
 	return maj, min, nil
 }
 
-func writeFile(filename, value string) error {
-	file, err := os.OpenFile(filename, os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-
-	_, err = file.WriteString(value)
-	if err != nil {
-		return err
-	}
-
-	err = file.Close()
-
-	return err
+func writeFile(exec exechelper.Executor, filename, value string) error {
+	result := exec.RunCommand(exechelper.ExecParams{
+		CmdName: "sh",
+		CmdArgs: []string{"-c", fmt.Sprintf("echo %s >> %s", value, filename)},
+	})
+	return result.Error
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
This PR adds cgroup v2 support to the recently introduced IO throttling feature. It also removes the requirement for a shell to be present by directly writing to the cgroup file system instead on relying on the shell to do so.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add cgroup v2 support to IO throttling
```
