### PR TITLE
update(ldm): mount /etc/hwameistor to container

### DIFF
--- a/helm/hwameistor/templates/local-disk-manager.yaml
+++ b/helm/hwameistor/templates/local-disk-manager.yaml
@@ -61,8 +61,9 @@ spec:
             readOnly: true
           - name: devmount
             mountPath: /dev
-          - name: etcmount
-            mountPath: /etc
+          - name: host-etc-hwameistor
+            mountPath: /etc/hwameistor
+            mountPropagation: "Bidirectional"
           - name: registration-dir
             mountPath: {{ template "hwameistor.kubeletRootDir" . }}/plugins_registry
           - name: plugin-dir
@@ -111,10 +112,10 @@ spec:
         hostPath:
           path: /dev
           type: Directory
-      - name: etcmount
+      - name: host-etc-hwameistor
         hostPath:
-          path: /etc
-          type: Directory
+          path: /etc/hwameistor
+          type: DirectoryOrCreate
       - name: socket-dir
         hostPath:
           path: {{ template "hwameistor.kubeletRootDir" . }}/plugins/disk.hwameistor.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Use /etc/hwameistor as mountpoint in container rather than /etc.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
