### PR TITLE
fix bug of displaying NVMe disk of LocalStoragePool node

### DIFF
--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
@@ -368,6 +368,8 @@ func (lsnController *LocalStorageNodeController) ListStorageNodeDisks(queryPage 
 				disk.LocalStoragePooLName = hwameistorapi.PoolNameForHDD
 			} else if diskList.Items[i].Spec.DiskAttributes.Type == hwameistorapi.DiskClassNameSSD {
 				disk.LocalStoragePooLName = hwameistorapi.PoolNameForSSD
+			} else if diskList.Items[i].Spec.DiskAttributes.Type == hwameistorapi.DiskClassNameNVMe {
+				disk.LocalStoragePooLName = hwameistorapi.PoolNameForNVMe
 			}
 
 			disk.TotalCapacityBytes = diskList.Items[i].Spec.Capacity


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
displaying of NVMe disks of LocalStoragePool node is missing, fix the bug so NVMe disks can be seen on the ui via hwameistor-apiserver
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
