### PR TITLE
fix(disk-claim): don't assign disks when owner in claim is empty

### DIFF
--- a/deploy/crds/hwameistor.io_localdiskclaims_crd.yaml
+++ b/deploy/crds/hwameistor.io_localdiskclaims_crd.yaml
@@ -127,6 +127,7 @@ spec:
                 type: string
             required:
             - nodeName
+            - owner
             type: object
           status:
             description: LocalDiskClaimStatus defines the observed state of LocalDiskClaim

--- a/deploy/crds/hwameistor.io_localdisknodes_crd.yaml
+++ b/deploy/crds/hwameistor.io_localdisknodes_crd.yaml
@@ -196,6 +196,7 @@ spec:
                         type: string
                     required:
                     - nodeName
+                    - owner
                     type: object
                   type: array
                 description: PoolExtendRecords record why disks are joined in the

--- a/deploy/crds/hwameistor.io_localstoragenodes_crd.yaml
+++ b/deploy/crds/hwameistor.io_localstoragenodes_crd.yaml
@@ -195,6 +195,7 @@ spec:
                         type: string
                     required:
                     - nodeName
+                    - owner
                     type: object
                   type: array
                 description: PoolExtendRecords record why disks are joined in the

--- a/pkg/apis/hwameistor/v1alpha1/localdiskclaim_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localdiskclaim_types.go
@@ -23,7 +23,8 @@ type LocalDiskClaimSpec struct {
 	DiskRefs []*v1.ObjectReference `json:"diskRefs,omitempty"`
 
 	// Owner represents which system owns this claim(e.g. local-storage, local-disk-manager)
-	Owner string `json:"owner,omitempty"`
+	// +kubebuilder:validation:Required
+	Owner string `json:"owner"`
 }
 
 type LocalDiskClaimSpecArray []LocalDiskClaimSpec

--- a/pkg/apis/hwameistor/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hwameistor/v1alpha1/zz_generated.deepcopy.go
@@ -598,7 +598,7 @@ func (in *LocalDiskVolumeStatus) DeepCopyInto(out *LocalDiskVolumeStatus) {
 	*out = *in
 	if in.DevLinks != nil {
 		in, out := &in.DevLinks, &out.DevLinks
-		*out = make(map[DevLinkType][]string, len(*in))
+		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
 			var outVal []string
 			if val == nil {

--- a/pkg/local-disk-manager/controller/localdiskclaim/localdiskclaim_controller_test.go
+++ b/pkg/local-disk-manager/controller/localdiskclaim/localdiskclaim_controller_test.go
@@ -415,6 +415,7 @@ func GenFakeLocalDiskClaimObject(status v1alpha1.DiskClaimStatus) *v1alpha1.Loca
 
 	Spec := v1alpha1.LocalDiskClaimSpec{
 		NodeName: fakeNodename,
+		Owner:    "local-storage",
 		Description: v1alpha1.DiskClaimDescription{
 			DiskType: diskTypeHDD,
 			Capacity: cap100G,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
fix #1051 
#### Special notes for your reviewer:
**owner** in LocalDiskClaim is required.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
