### PR TITLE
add field to record device history info

### DIFF
--- a/deploy/crds/hwameistor.io_localdisks_crd.yaml
+++ b/deploy/crds/hwameistor.io_localdisks_crd.yaml
@@ -191,6 +191,13 @@ spec:
                 description: HasPartition represents if the disk has partitions or
                   not
                 type: boolean
+              preDevicePath:
+                description: PreDevicePath represents the last device path in the
+                  OS
+                type: string
+              preNodeName:
+                description: PreNodeName represents the node where the disk was attached
+                type: string
               raidInfo:
                 description: RAIDInfo contains RAID information
                 properties:

--- a/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localdisk_types.go
@@ -173,11 +173,17 @@ type LocalDiskSpec struct {
 	// +kubebuilder:validation:Required
 	NodeName string `json:"nodeName"`
 
+	// PreNodeName represents the node where the disk was attached
+	PreNodeName string `json:"preNodeName,omitempty"`
+
 	// UUID global unique identifier of the disk
 	UUID string `json:"uuid,omitempty"`
 
 	// DevicePath is the disk path in the OS
 	DevicePath string `json:"devicePath,omitempty"`
+
+	// PreDevicePath represents the last device path in the OS
+	PreDevicePath string `json:"preDevicePath,omitempty"`
 
 	// DevLinks are symbol links for this device
 	DevLinks []string `json:"devLinks"`

--- a/pkg/apis/hwameistor/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hwameistor/v1alpha1/zz_generated.deepcopy.go
@@ -598,7 +598,7 @@ func (in *LocalDiskVolumeStatus) DeepCopyInto(out *LocalDiskVolumeStatus) {
 	*out = *in
 	if in.DevLinks != nil {
 		in, out := &in.DevLinks, &out.DevLinks
-		*out = make(map[DevLinkType][]string, len(*in))
+		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
 			var outVal []string
 			if val == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
as part of #982 

since the disk is removable, you need to record the last disk information, including node information and paths.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
