### PR TITLE
yum install xfsprogs when build local-disk-manager container image

### DIFF
--- a/build/local-disk-manager/Dockerfile
+++ b/build/local-disk-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y smartmontools lsscsi e4fsprogs && \
+RUN yum install -y xfsprogs smartmontools lsscsi e4fsprogs && \
     yum upgrade nss -y
 
 COPY ./_build/local-disk-manager /local-disk-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
When pod mount hwameistor disk volume, local-disk-manager pod will fail to support since mkfs.xfs command doesn't exist. We need to install xfsprogs when build local-disk-manager container image.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
