### PR TITLE
Add cgroupsv2 support

### DIFF
--- a/pkg/local-storage/member/node/qos/cgroups.go
+++ b/pkg/local-storage/member/node/qos/cgroups.go
@@ -2,7 +2,8 @@ package qos
 
 import (
 	"fmt"
-	"os"
+	"github.com/hwameistor/hwameistor/pkg/exechelper"
+	"github.com/hwameistor/hwameistor/pkg/exechelper/nsexecutor"
 	"path/filepath"
 	"syscall"
 
@@ -26,11 +27,11 @@ func NewVolumeCgroupsManager() (VolumeCgroupsManager, error) {
 	mode := cgroups.Mode()
 	switch mode {
 	case cgroups.Legacy:
-		return &cgroupV1{}, nil
+		return &cgroupV1{nsexecutor.New()}, nil
 	case cgroups.Hybrid:
-		return &cgroupV2{hybridCGroupsIOLimits}, nil
+		return &cgroupV2{nsexecutor.New(), hybridCGroupsIOLimits}, nil
 	case cgroups.Unified:
-		return &cgroupV2{cgroupV2IOLimits}, nil
+		return &cgroupV2{nsexecutor.New(), cgroupV2IOLimits}, nil
 	case cgroups.Unavailable:
 		return &noop{}, fmt.Errorf("cgroups is not available")
 	}
@@ -40,7 +41,9 @@ func NewVolumeCgroupsManager() (VolumeCgroupsManager, error) {
 var _ VolumeCgroupsManager = &cgroupV1{}
 
 // cgroupV1 is the implementation of VolumeCgroupsManager for cgroup v1.
-type cgroupV1 struct{}
+type cgroupV1 struct {
+	exec exechelper.Executor
+}
 
 // ConfigureQoSForDevice configures the QoS for a volume.
 func (c *cgroupV1) ConfigureQoSForDevice(devPath string, iops, throughput int64) error {
@@ -50,25 +53,25 @@ func (c *cgroupV1) ConfigureQoSForDevice(devPath string, iops, throughput int64)
 	}
 
 	filename := filepath.Join(cgroupV1BlkioPath, "blkio.throttle.read_bps_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
 	if err != nil {
 		return err
 	}
 
 	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.write_bps_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
 	if err != nil {
 		return err
 	}
 
 	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.read_iops_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
 	if err != nil {
 		return err
 	}
 
 	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.write_iops_device")
-	err = writeFile(filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
 	if err != nil {
 		return err
 	}
@@ -85,6 +88,7 @@ func (n *noop) ConfigureQoSForDevice(string, int64, int64) error {
 
 // cgroupV2 is the implementation of VolumeCgroupsManager for cgroup v2.
 type cgroupV2 struct {
+	exec         exechelper.Executor
 	iolimitsPath string
 }
 
@@ -96,7 +100,7 @@ func (c *cgroupV2) ConfigureQoSForDevice(devPath string, iops, throughput int64)
 	}
 
 	filename := filepath.Join(c.iolimitsPath)
-	err = writeFile(filename, fmt.Sprintf("%d:%d rbps=%d wbps=%d riops=%d wiops=%d", major, minor, throughput, throughput, iops, iops))
+	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d rbps=%d wbps=%d riops=%d wiops=%d", major, minor, throughput, throughput, iops, iops))
 	if err != nil {
 		return err
 	}
@@ -116,18 +120,10 @@ func getDeviceNumber(devicePath string) (uint64, uint64, error) {
 	return maj, min, nil
 }
 
-func writeFile(filename, value string) error {
-	file, err := os.OpenFile(filename, os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-
-	_, err = file.WriteString(value)
-	if err != nil {
-		return err
-	}
-
-	err = file.Close()
-
-	return err
+func writeFile(exec exechelper.Executor, filename, value string) error {
+	result := exec.RunCommand(exechelper.ExecParams{
+		CmdName: "sh",
+		CmdArgs: []string{"-c", fmt.Sprintf("echo %s >> %s", value, filename)},
+	})
+	return result.Error
 }

--- a/pkg/local-storage/member/node/qos/cgroups.go
+++ b/pkg/local-storage/member/node/qos/cgroups.go
@@ -2,18 +2,13 @@ package qos
 
 import (
 	"fmt"
-	"github.com/hwameistor/hwameistor/pkg/exechelper"
-	"github.com/hwameistor/hwameistor/pkg/exechelper/nsexecutor"
 	"path/filepath"
 	"syscall"
 
 	"github.com/containerd/cgroups/v3"
-)
 
-const (
-	cgroupV1BlkioPath     = "/sys/fs/cgroup/blkio"
-	cgroupV2IOLimits      = "/sys/fs/cgroup/kubepods/io.max"
-	hybridCGroupsIOLimits = "/sys/fs/cgroup/unified/kubepods/io.max"
+	"github.com/hwameistor/hwameistor/pkg/exechelper"
+	"github.com/hwameistor/hwameistor/pkg/exechelper/nsexecutor"
 )
 
 // VolumeCgroupsManager is the interface to configure QoS for a volume.
@@ -24,14 +19,51 @@ type VolumeCgroupsManager interface {
 
 // NewVolumeCgroupsManager returns a VolumeCgroupsManager according to the cgroups mode.
 func NewVolumeCgroupsManager() (VolumeCgroupsManager, error) {
+	exec := nsexecutor.New()
 	mode := cgroups.Mode()
 	switch mode {
 	case cgroups.Legacy:
-		return &cgroupV1{nsexecutor.New()}, nil
+		return &cgroupV1{exec: exec, blkioPath: "/sys/fs/cgroup/blkio"}, nil
 	case cgroups.Hybrid:
-		return &cgroupV2{nsexecutor.New(), hybridCGroupsIOLimits}, nil
+		// Is systemd driver?
+		ioPath := "/sys/fs/cgroup/unified/kubepods.slice/io.max"
+		err := exec.RunCommand(exechelper.ExecParams{
+			CmdName: "stat",
+			CmdArgs: []string{ioPath},
+		}).Error
+		if err == nil {
+			return &cgroupV2{exec, ioPath}, nil
+		}
+		// Is cgroup driver?
+		ioPath = "/sys/fs/cgroup/unified/kubepods/io.max"
+		err = exec.RunCommand(exechelper.ExecParams{
+			CmdName: "stat",
+			CmdArgs: []string{ioPath},
+		}).Error
+		if err == nil {
+			return &cgroupV2{exec, ioPath}, nil
+		}
+		return &noop{}, nil
 	case cgroups.Unified:
-		return &cgroupV2{nsexecutor.New(), cgroupV2IOLimits}, nil
+		// Is systemd driver?
+		ioPath := "/sys/fs/cgroup/kubepods.slice/io.max"
+		err := exec.RunCommand(exechelper.ExecParams{
+			CmdName: "stat",
+			CmdArgs: []string{ioPath},
+		}).Error
+		if err == nil {
+			return &cgroupV2{exec, ioPath}, nil
+		}
+		// Is cgroup driver?
+		ioPath = "/sys/fs/cgroup/kubepods/io.max"
+		err = exec.RunCommand(exechelper.ExecParams{
+			CmdName: "stat",
+			CmdArgs: []string{ioPath},
+		}).Error
+		if err == nil {
+			return &cgroupV2{exec, ioPath}, nil
+		}
+		return &noop{}, nil
 	case cgroups.Unavailable:
 		return &noop{}, fmt.Errorf("cgroups is not available")
 	}
@@ -42,7 +74,8 @@ var _ VolumeCgroupsManager = &cgroupV1{}
 
 // cgroupV1 is the implementation of VolumeCgroupsManager for cgroup v1.
 type cgroupV1 struct {
-	exec exechelper.Executor
+	blkioPath string
+	exec      exechelper.Executor
 }
 
 // ConfigureQoSForDevice configures the QoS for a volume.
@@ -52,25 +85,25 @@ func (c *cgroupV1) ConfigureQoSForDevice(devPath string, iops, throughput int64)
 		return err
 	}
 
-	filename := filepath.Join(cgroupV1BlkioPath, "blkio.throttle.read_bps_device")
+	filename := filepath.Join(c.blkioPath, "blkio.throttle.read_bps_device")
 	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
 	if err != nil {
 		return err
 	}
 
-	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.write_bps_device")
+	filename = filepath.Join(c.blkioPath, "blkio.throttle.write_bps_device")
 	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, throughput))
 	if err != nil {
 		return err
 	}
 
-	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.read_iops_device")
+	filename = filepath.Join(c.blkioPath, "blkio.throttle.read_iops_device")
 	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
 	if err != nil {
 		return err
 	}
 
-	filename = filepath.Join(cgroupV1BlkioPath, "blkio.throttle.write_iops_device")
+	filename = filepath.Join(c.blkioPath, "blkio.throttle.write_iops_device")
 	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d %d", major, minor, iops))
 	if err != nil {
 		return err
@@ -99,12 +132,29 @@ func (c *cgroupV2) ConfigureQoSForDevice(devPath string, iops, throughput int64)
 		return err
 	}
 
-	filename := filepath.Join(c.iolimitsPath)
-	err = writeFile(c.exec, filename, fmt.Sprintf("%d:%d rbps=%d wbps=%d riops=%d wiops=%d", major, minor, throughput, throughput, iops, iops))
-	if err != nil {
-		return err
+	if throughput == 0 {
+		err = writeFile(c.exec, c.iolimitsPath, fmt.Sprintf("%d:%d rbps=max wbps=max", major, minor))
+		if err != nil {
+			return err
+		}
+	} else {
+		err = writeFile(c.exec, c.iolimitsPath, fmt.Sprintf("%d:%d rbps=%d wbps=%d", major, minor, throughput, throughput))
+		if err != nil {
+			return err
+		}
 	}
 
+	if iops == 0 {
+		err = writeFile(c.exec, c.iolimitsPath, fmt.Sprintf("%d:%d riops=max wiops=max", major, minor))
+		if err != nil {
+			return err
+		}
+	} else {
+		err = writeFile(c.exec, c.iolimitsPath, fmt.Sprintf("%d:%d riops=%d wiops=%d", major, minor, iops, iops))
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

This PR adds cgroup v2 support to the recently introduced IO throttling feature. 

#### Special notes for your reviewer:

This PR is based on #954. Thank @LucaDev for your contribution. We need add this feature in the next release.

Test output:

```
root@k8s-master:/home/ubuntu2204# kubectl exec -it pod-sample-644f7b89bf-zh7zs  -- dd if=/dev/zero of=/data/test bs=8M count=1
1+0 records in
1+0 records out
8388608 bytes (8.0MB) copied, 0.020760 seconds, 385.4MB/s
root@k8s-master:/home/ubuntu2204# kubectl exec -it pod-sample-644f7b89bf-zh7zs  -- dd if=/dev/zero of=/data/test bs=8M count=1
1+0 records in
1+0 records out
8388608 bytes (8.0MB) copied, 4.588758 seconds, 1.7MB/s
root@k8s-master:/home/ubuntu2204# kubectl exec -it pod-sample-644f7b89bf-zh7zs  -- dd if=/dev/zero of=/data/test bs=8M count=1
1+0 records in
1+0 records out
8388608 bytes (8.0MB) copied, 6.932077 seconds, 1.2MB/s
root@k8s-master:/home/ubuntu2204# kubectl exec -it pod-sample-644f7b89bf-zh7zs  -- dd if=/dev/zero of=/data/test bs=8M count=1
1+0 records in
1+0 records out
8388608 bytes (8.0MB) copied, 7.013371 seconds, 1.1MB/s
root@k8s-master:/home/ubuntu2204# kubectl exec -it pod-sample-644f7b89bf-zh7zs  -- dd if=/dev/zero of=/data/test bs=8M count=1
1+0 records in
1+0 records out
8388608 bytes (8.0MB) copied, 6.440413 seconds, 1.2MB/s

root@k8s-master:/home/ubuntu2204# cat /sys/fs/cgroup/kubepods.slice/io.max
253:0 rbps=1000000 wbps=1000000 riops=100 wiops=100
``` 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
volume qos adds cgroupsv2 support
```
