### PR TITLE
fix(snaprestore): set restore timeout 600s as default

### DIFF
--- a/pkg/local-storage/member/node/storage/executor_dd.go
+++ b/pkg/local-storage/member/node/storage/executor_dd.go
@@ -20,6 +20,12 @@ var (
 	once               sync.Once
 )
 
+const (
+	DiskDumpCMD       = "dd"
+	DiskDumpTimeout   = 60 * 10 // seconds
+	DiskDumpBlockSize = "bs=10M"
+)
+
 func newDDExecutor() *ddExecutor {
 	once.Do(func() {
 		ddExecutorInstance = &ddExecutor{
@@ -43,12 +49,13 @@ func (dd *ddExecutor) RestoreVolumeReplicaSnapshot(snapshotRestore *apisv1alpha1
 
 	// example：dd if=/dev/LocalStorage_PoolHDD/snapshot of=/dev/LocalStorage_PoolHDD/volume-new bs=10M
 	dataCopyCommand := exechelper.ExecParams{
-		CmdName: "dd",
+		CmdName: DiskDumpCMD,
 		CmdArgs: []string{
 			fmt.Sprintf("if=%s", inputDevicePath),
 			fmt.Sprintf("of=%s", outPutDevicePath),
-			"bs=10M",
+			DiskDumpBlockSize,
 		},
+		Timeout: DiskDumpTimeout,
 	}
 
 	dd.logger.WithField("restoreVolume", outPutDevicePath).Info("Start restoring snapshot")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
set larger timeout for snapshot restore when the device's IO performance is low or the volume is large.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
