### PR TITLE
Clean up advanced_features

### DIFF
--- a/docs/docs/quick_start/advanced_features/disk_expansion.md
+++ b/docs/docs/quick_start/advanced_features/disk_expansion.md
@@ -72,6 +72,8 @@ Finally, check if the new disk has been added into the node's storage pool succe
 kubectl get localstoragenode k8s-worker-4
 ```
 
+The output may look like:
+
 ```yaml
 apiVersion: hwameistor.io/v1alpha1
 kind: LocalStorageNode

--- a/docs/docs/quick_start/advanced_features/fast_failover.md
+++ b/docs/docs/quick_start/advanced_features/fast_failover.md
@@ -5,45 +5,47 @@ sidebar_label: "Fast Failover"
 
 # Application Fast Failover
 
-When the stateful application (i.e. Pod with HwameiStor volume) runs into a problem, especially caused by the node issue, 
-it's important to reschedule the Pod to another health node and keep running.
+When the stateful application (i.e. Pod with HwameiStor volume) runs into a problem, especially caused by the node issue,
+it's important to reschedule the Pod to another healthy node and keep running.
 
-However, due to the design of the Kubernetes' StatefulSet and Deployment, 
-it will wait a long time (e.g. 5 mins) before rescheduling the Pod. 
+However, due to the design of the Kubernetes' StatefulSet and Deployment,
+it will wait a long time (e.g. 5 mins) before rescheduling the Pod.
 Especially, it will never reschedule the Pod automatically for the StatefulSet Pod.
 This will cause the application stop, and even cause a huge business loss.
 
-HwameiStor provides a feature of fast failover to solve this problem. When identifying the application issue, 
-it will reschedule the Pod immediately without waiting for a very long time. 
-HwameiStor will fail the Pod over to another health node, and ensure the required data volumes are also located at the node. 
-So, the application can continue to work. 
+HwameiStor provides a feature of fast failover to solve this problem. When identifying the application issue,
+it will reschedule the Pod immediately without waiting for a very long time.
+HwameiStor will fail the Pod over to another healthy node, and ensure the required data volumes are also located at the node.
+So, the application can continue to work.
 
-# How to use
+## How to use
 
 HwameiStor provides the fast failover considering the two cases:
 
 * Node Failure  
   
   When a node fails, all the Pods on this node can't work any more。As to the Pod using HwameiStor volume，
-  it's necessary to reschedule to another health node with the associated data volume replica.
-  User can trigger the fast failover for this node by:
-  ```
+  it's necessary to reschedule to another healthy node with the associated data volume replica.
+  You can trigger the fast failover for this node by:
+
   Add a label to this node:
 
+  ```bash
   kubectl label node <nodeName> hwameistor.io/failover=start
+  ```
 
   When the fast failover completes, the label will be modified as:
 
+  ```console
   hwameistor.io/failover=completed
   ```
   
 * Pod Failure
 
-  When a Pod fails, user can trigger the fast failover for it by:
-  ```
-  Add a lable to this Pod:
+  When a Pod fails, you can trigger the fast failover for it by adding a lable to this Pod:
 
+  ```bash
   kubectl label pod <podName> hwameistor.io/failover=start
+  ```
 
   When the fast failover completes, the old Pod will be deleted and then the new one will be created on a new node.
-  ```

--- a/docs/docs/quick_start/advanced_features/system_audit.md
+++ b/docs/docs/quick_start/advanced_features/system_audit.md
@@ -9,7 +9,7 @@ It's important to record the information about the system operation history. Hwa
 
 The audit information is easier for user to understant and parse for various purposes.
 
-# How to use
+## How to use
 
 HwameiStor designs a new CRD for every resource as below:
 
@@ -22,13 +22,13 @@ spec:
   resourceName:
   records:
   - action:
-    actionContent: #in JSON format
+    actionContent: # in JSON format
     time:
     state:
-    stateContent: #in JSON format
+    stateContent: # in JSON format
 ```
 
-For instance, let's look a audit information of a volume:
+For instance, let's look at audit information of a volume:
 
 ```yaml
 apiVersion: hwameistor.io/v1alpha1

--- a/docs/docs/quick_start/advanced_features/volume_eviction.md
+++ b/docs/docs/quick_start/advanced_features/volume_eviction.md
@@ -71,8 +71,8 @@ status:
       usedVolumeCount: 1
       volumeCapacityBytesLimit: 17175674880
       # ** make sure volumes is empty ** #
-      volumes:  
-  state: Ready  
+      volumes:
+  state: Ready
 ```
 
 Check if there is any volume replica still located in the evicted node by running:

--- a/docs/docs/quick_start/advanced_features/volume_provisioned_io.md
+++ b/docs/docs/quick_start/advanced_features/volume_provisioned_io.md
@@ -164,8 +164,8 @@ According to the print out, the LocalVolume CR for the PVC is `pvc-cac82087-6f6c
 
 ### Modify the LocalVolume CR
 
-```
-$ kubectl edit localvolume pvc-cac82087-6f6c-493a-afcd-09480de712ed
+```bash
+kubectl edit localvolume pvc-cac82087-6f6c-493a-afcd-09480de712ed
 ```
 
 In the editor, find the `spec.volumeQoS` section and modify the `iops` and `throughput` fields. By the way, an empty value means no limit.
@@ -180,7 +180,7 @@ once the Kubernetes supports [it](https://github.com/kubernetes/enhancements/tre
 HwameiStor uses the [cgroupv1](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt) or [cgroupv2](https://www.kernel.org/doc/Documentation/cgroup-v2.txt)
 to limit the IOPS and throughput of a volume, so you can use the following command to check the actual IOPS and throughput of a volume.
 
-```
+```console
 $ lsblk
 NAME            MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
 sda               8:0    0   160G  0 disk
@@ -214,6 +214,7 @@ $ cat /sys/fs/cgroup/blkio/blkio.throttle.write_bps_device
 253:3 1048576
 
 # if cgroup version is v2.
+
 # cat /sys/fs/cgroup/kubepods.slice/io.max
 253:0 rbps=1048576 wbps=1048576 riops=100 wiops=100
 ```

--- a/docs/docs/quick_start/advanced_features/volume_snapshot.md
+++ b/docs/docs/quick_start/advanced_features/volume_snapshot.md
@@ -15,7 +15,7 @@ To avoid data inconsistency, please pause or stop I/O before taking a snapshot.
 
 Please follow the steps below to create a VolumeSnapshotClass and a VolumeSnapshot to use it.
 
-## Create a new VolumeSnapshotClass
+## Create VolumeSnapshotClass
 
 By default, HwameiStor does not automatically create a VolumeSnapshotClass during installation, so you need to create a VolumeSnapshotClass manually.
 
@@ -39,7 +39,6 @@ driver: lvm.hwameistor.io
 If the snapsize parameter is not specified, the size of the created snapshot is consistent with the size of the source volume.
 :::
 
-
 After you create a VolumeSnapshotClass, you can use it to create VolumeSnapshot.
 
 ## Create a VolumeSnapshot using the VolumeSnapshotClass
@@ -56,28 +55,29 @@ spec:
   source:
     persistentVolumeClaimName: local-storage-pvc-lvm
 ```
+
 - persistentVolumeClaimName：It specifies the PVC to create the VolumeSnapshot
 
 After creating a VolumeSnapshot, you can check the VolumeSnapshot using the following command.
-```yaml
+
+```console
 $ kubectl get vs
 NAME                             READYTOUSE   SOURCEPVC               SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                     SNAPSHOTCONTENT                                    CREATIONTIME   AGE
 snapshot-local-storage-pvc-lvm   true         local-storage-pvc-lvm                           1Gi           hwameistor-storage-lvm-snapshot   snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110   53y            2m57s
-
 ```
 
 After creating a VolumeSnapshot, you can check the Hwameistor LocalvolumeSnapshot using the following command.
 
-```yaml
+```console
 $ kubectl get lvs
 NAME                                               CAPACITY     SOURCEVOLUME                               STATE   MERGING   INVALID   AGE
 snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110   1073741824   pvc-967baffd-ce10-4739-b996-87c9ed24e635   Ready                       5m31s
-
 ```
+
 - CAPACITY: The capacity size of the snapshot
 - SourceVOLUME: The source volume name of the snapshot
-- MERGING: Whether the snapshot is in a merged state (usually triggered by * rollback operation *)
-- INVALID: Whether the snapshot is invalidated (usually triggered when * the snapshot capacity is full *)
+- MERGING: Whether the snapshot is in a merged state (usually triggered by *rollback operation*)
+- INVALID: Whether the snapshot is invalidated (usually triggered when *the snapshot capacity is full*)
 - AGE: The actual creation time of the snapshot (different from the CR creation time, this time is the creation time of the underlying snapshot data volume)
 
 After creating a VolumeSnapshot, you can restore and rollback the VolumeSnapshot.
@@ -104,7 +104,6 @@ spec:
       storage: 1Gi
 ```
 
-
 ## Rollback VolumeSnapshot
 
 :::note
@@ -123,10 +122,12 @@ spec:
   sourceVolumeSnapshot: snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110
   restoreType: "rollback"
 ```
+
 - sourceVolumeSnapshot：It specifies the VolumeSnapshot to be rollback.
 
 Observing the created LocalVolumeSnapshotRestore, you can understand the entire rollback process through the state. After the rollback is complete, the corresponding LocalVolumeSnapshotRestore will be deleted.
-```yaml
+
+```console
 NAME            TARGETVOLUME                               SOURCESNAPSHOT                                     STATE        AGE
 restore-test2   pvc-967baffd-ce10-4739-b996-87c9ed24e635   snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110   Submitted    0s
 restore-test2   pvc-967baffd-ce10-4739-b996-87c9ed24e635   snapcontent-81a1f605-c28a-4e60-8c78-a3d504cbf6d9   InProgress   0s

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/disk_expansion.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/disk_expansion.md
@@ -8,9 +8,7 @@ sidebar_label: "数据盘扩展"
 当存储系统中的某个节点存储容量不足时，可以通过为该节点增加磁盘扩充容量。
 在 HwameiStor 中，可以通过下列步骤完成为节点增加磁盘（数据盘）。
 
-## 步骤
-
-### 1. 准备新的存储磁盘
+## 准备新的存储磁盘
 
 从 HwameiStor 中选择需要扩容的节点，将新增磁盘插入该节点的磁盘槽位。
 本例中，所用的新增存储节点和磁盘信息如下所示：
@@ -21,20 +19,36 @@ sidebar_label: "数据盘扩展"
 
 在新增磁盘被插入到 HwameiStor 存储节点 `k8s-worker-4` 后，检查该节点上的新磁盘状态，如下：
 
-```console
-# 1. 检查新增磁盘是否成功插入节点，并被正确识别
-$ ssh root@k8s-worker-4
-$ lsblk | grep sdc
-sdc        8:32     0     20G  1 disk
+1. 检查新增磁盘是否成功插入节点，并被正确识别
 
-# 2. 检查 HwameiStor 是否为新增磁盘正确创建资源 LocalDisk，并且状态为 `Unclaimed`
-$ kubectl get localdisk | grep k8s-worker-4 | grep sdc
-k8s-worker-4-sdc   k8s-worker-4       Available 
-```
+   ```bash
+   ssh root@k8s-worker-4
+   lsblk | grep sdc
+   ```
 
-### 2. 将新增磁盘加入到节点的存储池
+   输出类似于：
 
-通过创建资源 LocalDiskClaim，将新增磁盘加入节点的存储池。如下所示。完成下列操作后，新磁盘应该被自动加入节点的 SSD 存储池中。如果该节点上没有 SSD 存储池，HwameiStor 会为其自动创建，并将新磁盘加入其中。
+   ```none
+   sdc        8:32     0     20G  1 disk
+   ```
+
+2. 检查 HwameiStor 是否为新增磁盘正确创建资源 LocalDisk，并且状态为 `Unclaimed`
+
+   ```bash
+   kubectl get localdisk | grep k8s-worker-4 | grep sdc
+   ```
+  
+   输出类似于：
+  
+   ```none
+   k8s-worker-4-sdc   k8s-worker-4       Available 
+   ```
+
+## 将新增磁盘加入到节点的存储池
+
+通过创建资源 LocalDiskClaim，将新增磁盘加入节点的存储池。
+完成下列操作后，新磁盘应该被自动加入节点的 SSD 存储池中。
+如果该节点上没有 SSD 存储池，HwameiStor 会为其自动创建，并将新磁盘加入其中。
 
 ```console
 $ kubectl apply -f - <<EOF
@@ -51,11 +65,17 @@ spec:
 EOF
 ```
 
-### 3. 后续检查
+## 后续检查
 
 完成上述步骤后，检查新增磁盘及其存储池的状态，确保节点和 HwameiStor 系统的正常运行。具体如下：
 
-```console
+```bash
+kubectl get localstoragenode k8s-worker-4
+```
+
+输出类似于：
+
+```yaml
 apiVersion: hwameistor.io/v1alpha1
 kind: LocalStorageNode
 metadata:

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/fast_failover.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/fast_failover.md
@@ -3,7 +3,7 @@ sidebar_position: 6
 sidebar_label: "应用故障恢复"
 ---
 
-# 快速故障恢复
+# 应用故障恢复
 
 针对 Kubernetes 中的有状态应用（挂载了 HwameiStor PVC 的 Pod ），当 Pod 或者 PVC 出现问题时，尤其是 Kubernetes 节点出现问题时，
 需要及时发现并重新调度，将 Pod 调度到其他健康的节点，并能成功挂载 PVC。
@@ -15,31 +15,33 @@ sidebar_label: "应用故障恢复"
 HwameiStor 为解决这类故障，提供了应用故障快速快速的能力。
 在发现应用出现故障时，在很短的时间内将应用调度至另外的健康节点，同时保证在新节点上有应用所需的数据卷副本，从而保证业务应用正常运行。
 
-# 使用方式
+## 使用方式
 
 HwameiStor 为两类情况提供了应用故障快速恢复机制：
 
 * 节点出现故障
   
   在这种情况下，该节点上的应用均无法正常运行。对于使用 HwameiStor 数据卷的应用，需要及时地将 Pod 重新调度到新的健康节点。
-  用户可以通过下列方式进行故障恢复：
-  ```
+  您可以通过下列方式进行故障恢复：
+
   为该节点打标签（Label）：
 
+  ```bash
   kubectl label node <nodeName> hwameistor.io/failover=start
+  ```
 
   当故障恢复完成后，上面的标签会变成：
 
+  ```console
   hwameistor.io/failover=completed
   ```
   
 * 应用 Pod 出现故障
 
-  在这种情况下，用户可以通过下列方式对 Pod 进行故障恢复：
-  ```
-  为该 Pod 打标签（Label）：
+  在这种情况下，您可以为该 Pod 打标签（Label）对 Pod 进行故障恢复：
 
+  ```bash
   kubectl label pod <podName> hwameistor.io/failover=start
+  ```
 
   当故障恢复完成后，旧的 Pod 会被删除，新的 Pod 会在新的节点上启动并正常运行。
-  ```

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/node_expansion.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/node_expansion.md
@@ -40,7 +40,8 @@ k8s-worker-4   10.6.182.103       Ready    8d
 
 ## 添加新增存储节点到 HwameiStor 系统
 
-为增加存储节点创建资源 LocalStorageClaim，以此为新增存储节点构建存储池。这样，节点就已经成功加入 HwameiStor 系统。具体如下：
+为增加存储节点创建资源 LocalStorageClaim，以此为新增存储节点构建存储池。
+这样，节点就已经成功加入 HwameiStor 系统。具体如下：
 
 ```console
 $ kubectl apply -f - <<EOF
@@ -60,8 +61,13 @@ EOF
 
 完成上述步骤后，检查新增存储节点及其存储池的状态，确保节点和 HwameiStor 系统的正常运行。具体如下：
 
-```console
-$ kubectl get localstoragenode k8s-worker-4 -o yaml
+```bash
+kubectl get localstoragenode k8s-worker-4 -o yaml
+```
+
+输出类似于：
+
+```yaml
 apiVersion: hwameistor.io/v1alpha1
 kind: LocalStorageNode
 metadata:

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/system_audit.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/system_audit.md
@@ -8,7 +8,7 @@ sidebar_label: "系统审计日志"
 为了记录 HwameiStor 集群系统的使用和操作历史信息，HwameiStor 提供了系统审计日志。该审计日志具有 HwameiStor 系统语义，易于用户查阅、解析。
 审计日志针对 HwameiStor 系统中的每类资源，记录其使用操作信息。该资源包括：Cluster、Node、StoragePool、Volume，等等。
 
-# 使用方式
+## 使用方式
 
 审计日志通过 CRD 的方式存入系统中，为每一个资源创建一个 CR 来记录其操作历史。该 CRD 如下：
 
@@ -21,12 +21,14 @@ spec:
   resourceName:
   records:
   - action:
-    actionContent: #in JSON format
+    actionContent: # in JSON format
     time:
     state:
-    stateContent: #in JSON format
+    stateContent: # in JSON format
 
 ```
+
+例如，我们可以看看数据卷的审计信息：
 
 ```yaml
 apiVersion: hwameistor.io/v1alpha1

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/volume_eviction.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/volume_eviction.md
@@ -10,19 +10,24 @@ HwameiStor 会将数据卷从一个节点迁移到另一个节点，同时保证
 当 Kubernetes 节点或者应用 Pod 由于某种原因被驱逐时，系统会自动发现节点或者 Pod 所关联的 HwameiStor 数据卷，并自动将其迁移到其他节点，从而保证被驱逐的 Pod 可以调度到其他节点并正常运行。
 此外，运维人员也可以主动迁移数据卷，从而平衡系统资源，保证系统平稳运行。
 
-**驱逐节点**
+## 驱逐节点
 
 在 Kubernetes 系统中，可以使用下列命令驱逐节点，将正在该节点上运行的 Pod 移除并迁移到其他节点上。
 同时，也将 Pod 使用的 HwameiStor 数据卷从该节点迁移到其他节点，保证 Pod 可以在其他节点上正常运行。
 
-```console
-$ kubectl drain k8s-node-1 --ignore-daemonsets=true
+```bash
+kubectl drain k8s-node-1 --ignore-daemonsets=true
 ```
 
 可以使用下列命令查看所关联的 HwameiStor 数据卷是否迁移成功。
 
-```console
-$ kubectl get LocalStorageNode k8s-node-1 -o yaml
+```bash
+kubectl get LocalStorageNode k8s-node-1 -o yaml
+```
+
+输出类似于：
+
+```yaml
 apiVersion: hwameistor.io/v1alpha1
 kind: LocalStorageNode
 metadata:
@@ -57,57 +62,65 @@ status:
       usedVolumeCount: 1
       volumeCapacityBytesLimit: 17175674880
       # ** 确保 volumes 为空 ** #
-      volumes:  
-  state: Ready  
+      volumes:
+  state: Ready
 ```
 
 同时，可以使用下列命令查看被驱逐节点上是否还有 HwameiStor 的数据卷。
 
+```bash
+kubectl get localvolumereplica
+```
+
+输出类似于：
+
 ```console
-$ kubectl get localvolumereplica
 NAME                                              CAPACITY     NODE         STATE   SYNCED   DEVICE                                                                  AGE
 pvc-1427f36b-adc4-4aef-8d83-93c59064d113-957f7g   1073741824   k8s-node-3   Ready   true     /dev/LocalStorage_PoolHDD-HA/pvc-1427f36b-adc4-4aef-8d83-93c59064d113   20h
 pvc-1427f36b-adc4-4aef-8d83-93c59064d113-qlpbmq   1073741824   k8s-node-2   Ready   true     /dev/LocalStorage_PoolHDD-HA/pvc-1427f36b-adc4-4aef-8d83-93c59064d113   30m
 pvc-6ca4c0d4-da10-4e2e-83b2-19cbf5c5e3e4-scrxjb   1073741824   k8s-node-2   Ready   true     /dev/LocalStorage_PoolHDD/pvc-6ca4c0d4-da10-4e2e-83b2-19cbf5c5e3e4      30m
 pvc-f8f017f9-eb09-4fbe-9795-a6e2d6873148-5t782b   1073741824   k8s-node-2   Ready   true     /dev/LocalStorage_PoolHDD-HA/pvc-f8f017f9-eb09-4fbe-9795-a6e2d6873148   30m
-
 ```
 
 在一些情况下，重启节点时，用户希望仍然保留数据卷在该节点上。可以通过在该节点上添加下列标签实现：
 
-```
-$ kubectl label node k8s-node-1 hwameistor.io/eviction=disable
+```bash
+kubectl label node k8s-node-1 hwameistor.io/eviction=disable
 ```
 
-**驱逐 Pod**
+## 驱逐 Pod
 
 当 Kubernetes 节点负载过重时，系统会选择性地驱逐一些 Pod，从而释放一些系统资源，保证其他 Pod 正常运行。
 如果被驱逐的 Pod 使用了 HwameiStor 数据卷，系统会捕捉到这个被驱逐的 Pod，自动将相关的 HwameiStor 数据卷迁移到其他节点，从而保证该 Pod 能正常运行。
 
-**迁移 Pod**
+## 迁移 Pod
 
 运维人员可以主动迁移应用 Pod 和其使用的 HwameiStor 数据卷，从而平衡系统资源，保证系统平稳运行。
 可以通过下列两种方式进行主动迁移：
 
-```console
-kubectl label pod mysql-pod hwameistor.io/eviction=start
-kubectl delete pod mysql-pod
-```
+- 方法 1
 
-```console
-$ cat << EOF | kubectl apply -f -
-apiVersion: hwameistor.io/v1alpha1
-kind: LocalVolumeMigrate
-metadata:
-  name: migrate-pvc-6ca4c0d4-da10-4e2e-83b2-19cbf5c5e3e4
-spec:
-  sourceNode: k8s-node-1
-  targetNodesSuggested: 
-  - k8s-node-2
-  - k8s-node-3
-  volumeName: pvc-6ca4c0d4-da10-4e2e-83b2-19cbf5c5e3e4
-  migrateAllVols: true
-EOF
+    ```bash
+    kubectl label pod mysql-pod hwameistor.io/eviction=start
+    kubectl delete pod mysql-pod
+    ```
 
-$ kubectl delete pod mysql-pod
-```
+- 方法 2
+
+    ```console
+    $ cat << EOF | kubectl apply -f -
+    apiVersion: hwameistor.io/v1alpha1
+    kind: LocalVolumeMigrate
+    metadata:
+      name: migrate-pvc-6ca4c0d4-da10-4e2e-83b2-19cbf5c5e3e4
+    spec:
+      sourceNode: k8s-node-1
+      targetNodesSuggested: 
+      - k8s-node-2
+      - k8s-node-3
+      volumeName: pvc-6ca4c0d4-da10-4e2e-83b2-19cbf5c5e3e4
+      migrateAllVols: true
+    EOF
+
+    $ kubectl delete pod mysql-pod
+    ```

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/volume_provisioned_io.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/volume_provisioned_io.md
@@ -162,8 +162,8 @@ pvc-cac82087-6f6c-493a-afcd-09480de712ed   LocalStorage_PoolHDD   1          107
 
 ### 修改 LocalVolume CR
 
-```
-$ kubectl edit localvolume pvc-cac82087-6f6c-493a-afcd-09480de712ed
+```bash
+kubectl edit localvolume pvc-cac82087-6f6c-493a-afcd-09480de712ed
 ```
 
 在编辑器中，找到 `spec.volumeQoS` 部分并修改 `iops` 和 `throughput` 字段。 顺便说一下，空值意味着没有限制。
@@ -177,7 +177,7 @@ $ kubectl edit localvolume pvc-cac82087-6f6c-493a-afcd-09480de712ed
 HwameiStor 使用 [cgroupv1](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt) 或 [cgroupv2](https://www.kernel.org/doc/Documentation/cgroup-v2.txt)
 来限制数据卷的 IOPS 和吞吐量，因此您可以使用以下命令来检查数据卷的实际 IOPS 和吞吐量。
 
-```
+```console
 $ lsblk
 NAME            MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
 sda               8:0    0   160G  0 disk

--- a/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/volume_snapshot.md
+++ b/docs/i18n/cn/docusaurus-plugin-content-docs/current/quick_start/advanced_features/volume_snapshot.md
@@ -5,7 +5,7 @@ sidebar_label: "数据卷快照"
 
 # 数据卷快照
 
-在 HwameiStor 中，它允许用户创建数据卷的快照，且可以基于数据卷快照进行还原、回滚操作。
+在 HwameiStor 中，它允许用户创建数据卷的快照（VolumeSnapshot），且可以基于数据卷快照进行还原、回滚操作。
 
 :::note
 目前仅支持对非高可用 LVM 类型数据卷创建快照。
@@ -13,13 +13,13 @@ sidebar_label: "数据卷快照"
 为了避免数据不一致，请先暂停或者停止 I/O 然后再打快照。
 :::
 
-请按照以下步骤创建卷快照类（VolumeSnapshotClass）和卷快照（VolumeSnapshot）来使用它。
+请按照以下步骤创建 VolumeSnapshotClass 和 VolumeSnapshot 来使用它。
 
-## 创建新的卷快照类（VolumeSnapshotClass）
+## 创建新的 VolumeSnapshotClass
 
-默认情况下，HwameiStor 在安装过程中不会自动创建这样的 卷快照类，因此您需要手动创建 卷快照类。
+默认情况下，HwameiStor 在安装过程中不会自动创建这样的 VolumeSnapshotClass，因此您需要手动创建 VolumeSnapshotClass。
 
-示例 卷快照类（VolumeSnapshotClass） 如下：
+示例 VolumeSnapshotClass 如下：
 
 ```yaml
 kind: VolumeSnapshotClass
@@ -39,12 +39,11 @@ driver: lvm.hwameistor.io
 如果不指定 snapsize 参数，那么创建的快照大小和源卷的大小一致。
 :::
 
+创建 VolumeSnapshotClass 后，您可以使用它来创建 VolumeSnapshot。
 
-创建 卷快照类 后，您可以使用它来创建 卷快照。
+## 使用 VolumeSnapshotClass 创建 VolumeSnapshot
 
-## 使用 卷快照类（VolumeSnapshotClass） 创建 卷快照（VolumeSnapshot）
-
-示例 卷快照（VolumeSnapshot） 如下：
+示例 VolumeSnapshot 如下：
 
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1
@@ -56,35 +55,36 @@ spec:
   source:
     persistentVolumeClaimName: local-storage-pvc-lvm
 ```
+
 - persistentVolumeClaimName：指定要创建快照的 PVC。
 
-创建 卷快照 后，您可以使用如下命令检查 卷快照。
-```yaml
+创建 VolumeSnapshot 后，您可以使用如下命令检查 VolumeSnapshot。
+
+```console
 $ kubectl get vs
 NAME                             READYTOUSE   SOURCEPVC               SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                     SNAPSHOTCONTENT                                    CREATIONTIME   AGE
 snapshot-local-storage-pvc-lvm   true         local-storage-pvc-lvm                           1Gi           hwameistor-storage-lvm-snapshot   snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110   53y            2m57s
-
 ```
 
-创建 卷快照 后，您可以使用如下命令检查 HwameiStor 本地卷快照。
+创建 VolumeSnapshot 后，您可以使用如下命令检查 HwameiStor 本地卷快照。
 
-```yaml
+```console
 $ kubectl get lvs
 NAME                                               CAPACITY     SOURCEVOLUME                               STATE   MERGING   INVALID   AGE
 snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110   1073741824   pvc-967baffd-ce10-4739-b996-87c9ed24e635   Ready                       5m31s
-
 ```
+
 - CAPACITY：快照的容量大小
 - SOURCEVOLUME：快照的源卷名称
-- MERGING：快照是否处于合并状态（一般由*回滚操作*触发）
-- INVALID：快照是否失效（一般在*快照容量写满*触发）
+- MERGING：快照是否处于合并状态（一般由**回滚操作**触发）
+- INVALID：快照是否失效（一般在**快照容量写满**触发）
 - AGE：快照真实创建的时间（不同于 CR 创建的时间，这个时间是底层快照数据卷的创建时间）
 
-创建 卷快照 后，您可以对卷快照进行还原、回滚操作。
+创建 VolumeSnapshot 后，您可以对 VolumeSnapshot 进行还原、回滚操作。
 
 ## 对卷快照进行还原操作
 
-可以创建pvc，对卷快照进行还原操作。具体如下：
+可以创建 pvc，对卷快照进行还原操作。具体如下：
 
 ```yaml
 apiVersion: v1
@@ -104,12 +104,11 @@ spec:
       storage: 1Gi
 ```
 
-
 ## 对卷快照进行回滚操作
 
 :::note
-对快照进行回滚必须先*停止源卷的 I/O*，比如先停止应用，等待回滚操作完全结束，
-并*确认数据一致性*之后再使用回滚后的数据卷。
+对快照进行回滚必须先**停止源卷的 I/O**，比如先停止应用，等待回滚操作完全结束，
+并**确认数据一致性**之后再使用回滚后的数据卷。
 :::
 
 可以通过创建资源 LocalVolumeSnapshotRestore，对卷快照进行回滚操作。具体如下：
@@ -123,10 +122,12 @@ spec:
   sourceVolumeSnapshot: snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110
   restoreType: "rollback"
 ```
-- sourceVolumeSnapshot：指定要进行回滚操作的 卷快照。
+
+- sourceVolumeSnapshot：指定要进行回滚操作的卷快照。
 
 对创建的 LocalVolumeSnapshotRestore 进行观察，可以通过状态了解整个回滚的过程。回滚结束后，对应的 LocalVolumeSnapshotRestore 会被删除。
-```yaml
+
+```console
 NAME            TARGETVOLUME                               SOURCESNAPSHOT                                     STATE        AGE
 restore-test2   pvc-967baffd-ce10-4739-b996-87c9ed24e635   snapcontent-0fc17697-68ea-49ce-8e4c-7a791e315110   Submitted    0s
 restore-test2   pvc-967baffd-ce10-4739-b996-87c9ed24e635   snapcontent-81a1f605-c28a-4e60-8c78-a3d504cbf6d9   InProgress   0s


### PR DESCRIPTION
#### What this PR does / why we need it:

- Keep text consistent between en and zh
- Remove trailing spaces
- Fix headings (e.g., heading 1 shall be unique on a page)
- Fix backtick symbols for code snippet
- Remove `$` if only one line of command, to provide convenience for copy/paste

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
