### PR TITLE
fix apiserver getnodedisk bug and add set-diskowner api

### DIFF
--- a/pkg/apiserver/api/disk.go
+++ b/pkg/apiserver/api/disk.go
@@ -45,3 +45,17 @@ type DiskRemoveReservedRsp struct {
 type DiskRemoveReservedRspBody struct {
 	DiskRemoveReservedRsp DiskRemoveReservedRsp `json:"data,omitempty"`
 }
+
+type DiskOwnerReqBody struct {
+	//[ local-storage]  [local-disk-manager] [system]
+	Owner string `json:"owner,omitempty"`
+}
+
+type DiskOwnerRsp struct {
+	DiskName string `json:"diskName,omitempty"`
+	Owner    string `json:"owner,omitempty"`
+}
+
+type DiskOwnerRspBody struct {
+	DiskOwnerRsp DiskOwnerRsp `json:"data,omitempty"`
+}

--- a/pkg/apiserver/api/model.go
+++ b/pkg/apiserver/api/model.go
@@ -107,6 +107,11 @@ type Pagination struct {
 	//Search string `protobuf:"bytes,5,opt,name=search,proto3" json:"search,omitempty"`
 }
 
+// disk path
+const (
+	DEV = "/dev/"
+)
+
 // disk class
 const (
 	DiskClassNameHDD  = "HDD"
@@ -348,4 +353,5 @@ type QueryPage struct {
 	VolumeEventName   string
 	Synced            string
 	OperationName     string
+	Owner             string
 }

--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
@@ -357,7 +357,7 @@ func (lsnController *LocalStorageNodeController) ListStorageNodeDisks(queryPage 
 			disk.TotalCapacityBytes = diskList.Items[i].Spec.Capacity
 			availableCapacityBytes := lsnController.getAvailableDiskCapacity(queryPage.NodeName, diskList.Items[i].Spec.DevicePath, diskList.Items[i].Spec.DiskAttributes.Type)
 			disk.AvailableCapacityBytes = availableCapacityBytes
-			diskShortName := strings.Split(diskList.Items[i].Spec.DevicePath, "/dev/")[1]
+			diskShortName := strings.Split(diskList.Items[i].Spec.DevicePath, hwameistorapi.DEV)[1]
 			disk.DiskPathShort = diskShortName
 
 			log.Infof("ListStorageNodeDisks queryPage.DiskState = %v", queryPage.DiskState)
@@ -378,11 +378,13 @@ func (lsnController *LocalStorageNodeController) ReserveStorageNodeDisk(queryPag
 
 	diskName := utils.ConvertNodeName(queryPage.NodeName) + "-" + deviceShortPath
 
-	ld, err := diskHandler.GetLocalDisk(client.ObjectKey{Name: diskName})
+	//ld, err := diskHandler.GetLocalDisk(client.ObjectKey{Name: diskName})
+	localDisks, err := diskHandler.ListLocalDiskByNodeDevicePath(queryPage.NodeName, hwameistorapi.DEV+queryPage.DeviceShortPath)
 	if err != nil {
 		log.Errorf("failed to get localDisk %s", err.Error())
 		return RspBody, err
 	}
+	ld := &localDisks[0]
 	log.Infof("ReserveStorageNodeDisk ld = %v", ld)
 	diskHandler = diskHandler.For(ld)
 	diskHandler.ReserveDisk()
@@ -409,11 +411,13 @@ func (lsnController *LocalStorageNodeController) RemoveReserveStorageNodeDisk(qu
 
 	diskName := utils.ConvertNodeName(queryPage.NodeName) + "-" + deviceShortPath
 
-	ld, err := diskHandler.GetLocalDisk(client.ObjectKey{Name: diskName})
+	//ld, err := diskHandler.GetLocalDisk(client.ObjectKey{Name: diskName})
+	localDisks, err := diskHandler.ListLocalDiskByNodeDevicePath(queryPage.NodeName, hwameistorapi.DEV+queryPage.DeviceShortPath)
 	if err != nil {
 		log.Errorf("failed to get localDisk %s", err.Error())
 		return RspBody, err
 	}
+	ld := &localDisks[0]
 	ld.Spec.Reserved = false
 	diskHandler = diskHandler.For(ld)
 
@@ -429,31 +433,66 @@ func (lsnController *LocalStorageNodeController) RemoveReserveStorageNodeDisk(qu
 	return RspBody, nil
 }
 
+func (lsnController *LocalStorageNodeController) SetStorageNodeDiskOwner(queryPage hwameistorapi.QueryPage, diskHandler *localdisk.Handler) (*hwameistorapi.DiskOwnerRspBody, error) {
+	var RspBody = &hwameistorapi.DiskOwnerRspBody{}
+	var diskOwnerRsp hwameistorapi.DiskOwnerRsp
+	deviceShortPath := queryPage.DeviceShortPath
+	RspBody.DiskOwnerRsp = diskOwnerRsp
+
+	diskName := utils.ConvertNodeName(queryPage.NodeName) + "-" + deviceShortPath
+
+	localDisks, err := diskHandler.ListLocalDiskByNodeDevicePath(queryPage.NodeName, hwameistorapi.DEV+queryPage.DeviceShortPath)
+	if err != nil {
+		log.Errorf("failed to get localDisk %s", err.Error())
+		return RspBody, err
+	}
+	ld := &localDisks[0]
+	//Unable to operate the operating system disk
+	if ld.Spec.Owner != "" {
+		log.Errorf("Only unclaimed disks can modify the disk owner")
+		return RspBody, err
+	}
+
+	log.Infof("SetStorageNodeDiskOwner ld = %v", ld)
+	diskHandler = diskHandler.For(ld)
+	diskHandler.SetOwnerDisk(queryPage.Owner)
+
+	err = diskHandler.Update()
+	if err != nil {
+		return RspBody, err
+	}
+
+	diskOwnerRsp.Owner = queryPage.Owner
+	diskOwnerRsp.DiskName = diskName
+
+	RspBody.DiskOwnerRsp = diskOwnerRsp
+
+	return RspBody, nil
+}
+
 func (lsnController *LocalStorageNodeController) GetStorageNodeDisk(page hwameistorapi.QueryPage, diskHandler *localdisk.Handler) (*hwameistorapi.LocalDiskInfo, error) {
 	var ldi = &hwameistorapi.LocalDiskInfo{}
-	nodeKey := client.ObjectKey{
-		Name: page.NodeName,
-	}
-	if lsn, err := lsnController.GetLocalStorageNode(nodeKey); err == nil {
-		for _, pool := range lsn.Status.Pools {
-			for _, disk := range pool.Disks {
-				ldi.LocalStoragePooLName = pool.Name
-				ldi.AvailableCapacityBytes = disk.CapacityBytes
 
-				localDisk, err := diskHandler.GetLocalDisk(types.NamespacedName{Name: page.DiskName})
-				if err != nil {
-					log.Errorf("failed to get localDisk %s", err.Error())
-					return ldi, err
-				}
-				ldi.LocalDisk = *localDisk
-				ldi.TotalCapacityBytes = localDisk.Spec.Capacity
-				diskShortName := strings.Split(localDisk.Spec.DevicePath, "/dev/")[1]
-				ldi.DiskPathShort = diskShortName
-			}
-		}
-	} else {
+	devicePath := hwameistorapi.DEV + page.DiskName
+	localDisks, err := diskHandler.ListLocalDiskByNodeDevicePath(page.NodeName, devicePath)
+	if err != nil {
+		log.Errorf("failed to get localDisk by path %s", err.Error())
 		return ldi, err
 	}
+
+	ldi.LocalDisk = localDisks[0]
+	ldi.TotalCapacityBytes = localDisks[0].Spec.Capacity
+	diskShortName := strings.Split(localDisks[0].Spec.DevicePath, hwameistorapi.DEV)[1]
+	ldi.DiskPathShort = diskShortName
+	if localDisks[0].Spec.DiskAttributes.Type == hwameistorapi.DiskClassNameHDD {
+		ldi.LocalStoragePooLName = hwameistorapi.PoolNameForHDD
+	} else if localDisks[0].Spec.DiskAttributes.Type == hwameistorapi.DiskClassNameSSD {
+		ldi.LocalStoragePooLName = hwameistorapi.PoolNameForSSD
+	} else if localDisks[0].Spec.DiskAttributes.Type == hwameistorapi.DiskClassNameNVMe {
+		ldi.LocalStoragePooLName = hwameistorapi.PoolNameForNVMe
+	}
+	ldi.AvailableCapacityBytes = lsnController.getAvailableDiskCapacity(page.NodeName, devicePath, ldi.Spec.DiskAttributes.Type)
+
 	return ldi, nil
 }
 
@@ -524,7 +563,7 @@ func (lsnController *LocalStorageNodeController) StorageNodePoolDisksList(page h
 					ldi.LocalStoragePooLName = pool.Name
 					ldi.AvailableCapacityBytes = disk.CapacityBytes
 
-					diskName := strings.Split(disk.DevPath, "/dev/")[1]
+					diskName := strings.Split(disk.DevPath, hwameistorapi.DEV)[1]
 					ldname := utils.ConvertNodeName(lsn.Spec.HostName) + "-" + diskName
 
 					log.Infof("StorageNodePoolDisksList ldname = %v", ldname)

--- a/pkg/apiserver/manager/hwameistor/localstoragepool_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragepool_controller.go
@@ -3,6 +3,7 @@ package hwameistor
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"math"
@@ -270,9 +271,10 @@ func (lspController *LocalStoragePoolController) ExpandStoragePool(nodeName, dis
 		return err
 	}
 
+	u := uuid.New()
 	claim := &apisv1alpha1.LocalDiskClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: strings.ToLower(fmt.Sprintf("%s-%s-claim", nodeName, diskType)),
+			Name: strings.ToLower(fmt.Sprintf("%s-%s-claim-%s", nodeName, diskType, u)),
 		},
 		Spec: apisv1alpha1.LocalDiskClaimSpec{
 			Owner:    owner,

--- a/pkg/local-disk-manager/handler/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk.go
@@ -181,6 +181,10 @@ func (ldHandler *Handler) ReserveDisk() {
 	ldHandler.localDisk.Spec.Reserved = true
 }
 
+func (ldHandler *Handler) SetOwnerDisk(owner string) {
+	ldHandler.localDisk.Spec.Owner = owner
+}
+
 func (ldHandler *Handler) FilterDisk(ldc *v1alpha1.LocalDiskClaim) bool {
 	// Bound disk
 	if ldHandler.filter.HasBoundWith(ldc.UID) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Because the naming rules of the localdisk module have been modified, the apiserver also needs to make corresponding modifications to obtain disk information.
Add set-diskowner api
#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
