### PR TITLE
enhance query efficiency in registry 

### DIFF
--- a/pkg/local-storage/member/node/local_disk_task_worker.go
+++ b/pkg/local-storage/member/node/local_disk_task_worker.go
@@ -104,8 +104,7 @@ func (m *manager) processLocalDiskAvailable(_ *apisv1alpha1.LocalDisk) error {
 func (m *manager) resizeStoragePoolCapacity(localDisk *apisv1alpha1.LocalDisk) error {
 	// find out if disk has used in StoragePool and compare recorded capacity and current capacity
 	// if capacity has been resized, rebuild localstorage registry and update node resource
-	registeredDisks := m.Storage().Registry().Disks()
-	registeredDisk, exist := registeredDisks[localDisk.Spec.DevicePath]
+	registeredDisk, exist := m.Storage().Registry().QueryDisk(localDisk.Spec.DevicePath)
 	if !exist {
 		return nil
 	}

--- a/pkg/local-storage/member/node/storage/registry.go
+++ b/pkg/local-storage/member/node/storage/registry.go
@@ -261,6 +261,33 @@ func (lr *localRegistry) HasVolumeReplica(vr *apisv1alpha1.LocalVolumeReplica) b
 	_, has := lr.replicas[vr.Spec.VolumeName]
 	return has
 }
+func (lr *localRegistry) QueryVolumeReplica(volumeName string) (*apisv1alpha1.LocalVolumeReplica, bool) {
+	lr.lock.Lock()
+	defer lr.lock.Unlock()
+	volumeReplica, has := lr.replicas[volumeName]
+	if has {
+		volumeReplica = volumeReplica.DeepCopy()
+	}
+	return volumeReplica, has
+}
+func (lr *localRegistry) QueryDisk(devPath string) (*apisv1alpha1.LocalDevice, bool) {
+	lr.lock.Lock()
+	defer lr.lock.Unlock()
+	disk, has := lr.disks[devPath]
+	if has {
+		disk = disk.DeepCopy()
+	}
+	return disk, has
+}
+func (lr *localRegistry) QueryPool(poolName string) (*apisv1alpha1.LocalPool, bool) {
+	lr.lock.Lock()
+	defer lr.lock.Unlock()
+	pool, has := lr.pools[poolName]
+	if has {
+		pool = pool.DeepCopy()
+	}
+	return pool, has
+}
 
 // UpdateCondition append current condition about LocalStorageNode, i.e. StorageExpandSuccess, StorageExpandFail, UnAvailable
 func (lr *localRegistry) UpdateCondition(condition apisv1alpha1.StorageNodeCondition) error {

--- a/pkg/local-storage/member/node/storage/storage.go
+++ b/pkg/local-storage/member/node/storage/storage.go
@@ -33,7 +33,7 @@ func (mgr *localVolumeReplicaManager) CreateVolumeReplica(replica *apisv1alpha1.
 		if err == ErrorReplicaExists {
 			mgr.logger.Infof("Replica %s has already exists.", replica.Spec.VolumeName)
 			newReplica := replica.DeepCopy()
-			currentReplica := mgr.registry.VolumeReplicas()[replica.Spec.VolumeName]
+			currentReplica, _ := mgr.registry.QueryVolumeReplica(replica.Spec.VolumeName)
 			newReplica.Status.AllocatedCapacityBytes = currentReplica.Status.AllocatedCapacityBytes
 			newReplica.Status.StoragePath = currentReplica.Status.StoragePath
 			newReplica.Status.DevicePath = currentReplica.Status.DevicePath
@@ -92,7 +92,7 @@ func (mgr *localVolumeReplicaManager) ExpandVolumeReplica(replica *apisv1alpha1.
 
 func (mgr *localVolumeReplicaManager) GetVolumeReplica(replica *apisv1alpha1.LocalVolumeReplica) (*apisv1alpha1.LocalVolumeReplica, error) {
 
-	currentReplica, exists := mgr.registry.VolumeReplicas()[replica.Spec.VolumeName]
+	currentReplica, exists := mgr.registry.QueryVolumeReplica(replica.Spec.VolumeName)
 	if !exists {
 		return nil, fmt.Errorf("not found")
 	}

--- a/pkg/local-storage/member/node/storage/types.go
+++ b/pkg/local-storage/member/node/storage/types.go
@@ -69,6 +69,9 @@ type LocalRegistry interface {
 	Disks() map[string]*apisv1alpha1.LocalDevice
 	Pools() map[string]*apisv1alpha1.LocalPool
 	VolumeReplicas() map[string]*apisv1alpha1.LocalVolumeReplica
+	QueryVolumeReplica(volumeName string) (*apisv1alpha1.LocalVolumeReplica, bool)
+	QueryDisk(devPath string) (*apisv1alpha1.LocalDevice, bool)
+	QueryPool(poolName string) (*apisv1alpha1.LocalPool, bool)
 	HasVolumeReplica(replica *apisv1alpha1.LocalVolumeReplica) bool
 	UpdateNodeForVolumeReplica(replica *apisv1alpha1.LocalVolumeReplica)
 	SyncNodeResources() error

--- a/pkg/local-storage/member/node/storage/validator.go
+++ b/pkg/local-storage/member/node/storage/validator.go
@@ -80,8 +80,7 @@ func (cr *validator) canExpandVolumeReplica(vr *apisv1alpha1.LocalVolumeReplica,
 }
 
 func (cr *validator) checkPoolVolumeCount(vr *apisv1alpha1.LocalVolumeReplica, reg LocalRegistry) error {
-	pools := reg.Pools()
-	if pool, has := pools[vr.Spec.PoolName]; has {
+	if pool, has := reg.QueryPool(vr.Spec.PoolName); has {
 		if pool.FreeVolumeCount <= 0 {
 			return ErrorInsufficientRequestResources
 		}
@@ -92,8 +91,7 @@ func (cr *validator) checkPoolVolumeCount(vr *apisv1alpha1.LocalVolumeReplica, r
 }
 
 func (cr *validator) checkPoolCapacity(vr *apisv1alpha1.LocalVolumeReplica, reg LocalRegistry) error {
-	pools := reg.Pools()
-	if pool, has := pools[vr.Spec.PoolName]; has {
+	if pool, has := reg.QueryPool(vr.Spec.PoolName); has {
 		if pool.FreeCapacityBytes < utils.NumericToLVMBytes(vr.Spec.RequiredCapacityBytes) {
 			return ErrorInsufficientRequestResources
 		}
@@ -104,8 +102,7 @@ func (cr *validator) checkPoolCapacity(vr *apisv1alpha1.LocalVolumeReplica, reg 
 }
 
 func (cr *validator) checkPerVolumeCapacityLimit(vr *apisv1alpha1.LocalVolumeReplica, reg LocalRegistry) error {
-	pools := reg.Pools()
-	if pool, has := pools[vr.Spec.PoolName]; has {
+	if pool, has := reg.QueryPool(vr.Spec.PoolName); has {
 		if pool.VolumeCapacityBytesLimit < utils.NumericToLVMBytes(vr.Spec.RequiredCapacityBytes) {
 			return ErrorOverLimitedRequestResource
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Considering the data race bug has been fixed before, many place where calls the`Disks`,`Pools`,`VolumeReplicas`  method need to copy the full map right now.But these place actually not require the full map,but just a single key they want. So maybe putting up the concurrent safety method `QueryVolumeReplicas` ,`QueryDisk`,`QueryPool` for just a single key query to avoid copy full data is a good way to enhance the query efficiency.  

FYI: #1238 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
