### PR TITLE
improve(diskclaim): only record disk claim events when disk is Available

### DIFF
--- a/pkg/local-disk-manager/handler/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
+	"github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
 	"github.com/hwameistor/hwameistor/pkg/local-disk-manager/filter"
 	"github.com/hwameistor/hwameistor/pkg/local-disk-manager/utils/kubernetes"
 )
@@ -205,7 +205,7 @@ func (ldHandler *Handler) FilterDisk(ldc *v1alpha1.LocalDiskClaim) bool {
 		IsNameFormatMatch().
 		GetTotalResult()
 }
-func (ldHandler *Handler) GetFilterFailMessages() map[string]struct{} {
+func (ldHandler *Handler) GetFilterFailMessages() map[string]bool {
 	return ldHandler.filter.FailedMessage
 }
 

--- a/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim.go
+++ b/pkg/local-disk-manager/handler/localdiskclaim/localdiskclaim.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
+	"github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
 	diskHandler "github.com/hwameistor/hwameistor/pkg/local-disk-manager/handler/localdisk"
 )
 
@@ -94,7 +94,7 @@ func (ldcHandler *Handler) AssignFreeDisk() error {
 		if !localDiskHandler.FilterDisk(diskClaim) {
 			// append the disk name to failed message map when localdisk is assigned failed
 			filterFailMessages := localDiskHandler.GetFilterFailMessages()
-			for reason, _ := range filterFailMessages {
+			for reason := range filterFailMessages {
 				if _, ok := localDiskFailedMessages[reason]; !ok {
 					localDiskFailedMessages[reason] = []string{}
 				}
@@ -115,10 +115,10 @@ func (ldcHandler *Handler) AssignFreeDisk() error {
 	if len(finalAssignedDisks) <= 0 {
 		var fullFailMessages []string
 		for reason, diskNames := range localDiskFailedMessages {
-			fullMsg := reason + ": " + strings.Join(diskNames, ",")
+			fullMsg := strings.Join(diskNames, ",") + " are " + reason
 			fullFailMessages = append(fullFailMessages, fullMsg)
 		}
-		ldcHandler.EventRecorder.Event(diskClaim, v1.EventTypeWarning, v1alpha1.LocalDiskClaimEventReasonAssignFail, strings.Join(fullFailMessages, "/"))
+		ldcHandler.EventRecorder.Event(diskClaim, v1.EventTypeWarning, v1alpha1.LocalDiskClaimEventReasonAssignFail, strings.Join(fullFailMessages, ";"))
 
 		log.Infof("There is no available disk assigned to %v", diskClaim.GetName())
 		return fmt.Errorf("there is no available disk assigned to %v", diskClaim.GetName())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
The scenario that troubles users is generally a disk they believe is available, that is, a disk in an Available state. If all the disk information is added to the event, it will make the event very long.

#### Special notes for your reviewer:
```shell
Warning  LocalDiskClaimAssignFail  18s (x12 over 28s)      localdiskclaim-controller  Assign free disk fail, due to error: there is no available disk assigned to 172-30-46-11-hdd-claim
Warning  LocalDiskClaimAssignFail  18s (x6 over 28s)       localdiskclaim-controller  localdisk-e98be39ca068dd7877b021e47c8e712b are LocalDiskOwnerUnMatch;localdisk-90a3849907d060920639f7ce16c6c4f0,localdisk-647045e3018fa21e22f3d96d049c87ad are LocalDiskHasReserved
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
