### PR TITLE
improve(apiserver): add owner check for SetStorageNodeDiskOwner api

### DIFF
--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
@@ -454,7 +454,7 @@ func (lsnController *LocalStorageNodeController) SetStorageNodeDiskOwner(queryPa
 
 	log.Infof("SetStorageNodeDiskOwner ld = %v", ld)
 	diskHandler = diskHandler.For(ld)
-	diskHandler.SetOwnerDisk(queryPage.Owner)
+	diskHandler.SetOwner(queryPage.Owner)
 
 	err = diskHandler.Update()
 	if err != nil {

--- a/pkg/local-disk-manager/handler/localdisk/localdisk.go
+++ b/pkg/local-disk-manager/handler/localdisk/localdisk.go
@@ -180,10 +180,6 @@ func (ldHandler *Handler) ReserveDisk() {
 	ldHandler.localDisk.Spec.Reserved = true
 }
 
-func (ldHandler *Handler) SetOwnerDisk(owner string) {
-	ldHandler.localDisk.Spec.Owner = owner
-}
-
 func (ldHandler *Handler) FilterDisk(ldc *v1alpha1.LocalDiskClaim) bool {
 	// Bound disk
 	if ldHandler.filter.HasBoundWith(ldc.UID) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
add owner check for `SetStorageNodeDiskOwner` api to prevent from setting a owner which not belongs to the hwameistor system.And remove the duplicated method.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
