### PR TITLE
improve(apiserver):move ldHandler for improving cohesion

### DIFF
--- a/pkg/apiserver/controller/NodeController.go
+++ b/pkg/apiserver/controller/NodeController.go
@@ -8,11 +8,8 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	mgrpkg "sigs.k8s.io/controller-runtime/pkg/manager"
-
 	hwameistorapi "github.com/hwameistor/hwameistor/pkg/apiserver/api"
 	"github.com/hwameistor/hwameistor/pkg/apiserver/manager"
-	"github.com/hwameistor/hwameistor/pkg/local-disk-manager/handler/localdisk"
 )
 
 type INodeController interface {
@@ -31,17 +28,11 @@ type INodeController interface {
 }
 
 type NodeController struct {
-	m           *manager.ServerManager
-	diskHandler *localdisk.Handler
+	m *manager.ServerManager
 }
 
-func NewNodeController(m *manager.ServerManager, mgr mgrpkg.Manager) INodeController {
-
-	//setIndexField(mgr.GetCache())
-	diskHandler := localdisk.NewLocalDiskHandler(mgr.GetClient(),
-		mgr.GetEventRecorderFor("localdisk-controller"))
-
-	return &NodeController{m, diskHandler}
+func NewNodeController(m *manager.ServerManager) INodeController {
+	return &NodeController{m}
 }
 
 //// setIndexField must be called after scheme has been added
@@ -320,7 +311,7 @@ func (n *NodeController) UpdateStorageNodeDisk(ctx *gin.Context) {
 	queryPage.DeviceShortPath = devicePath
 
 	if reserve == true {
-		diskReservedRsp, err := n.m.StorageNodeController().ReserveStorageNodeDisk(queryPage, n.diskHandler)
+		diskReservedRsp, err := n.m.StorageNodeController().ReserveStorageNodeDisk(queryPage)
 		if err != nil {
 			failRsp.ErrCode = 500
 			failRsp.Desc = "ReserveStorageNodeDisk Failed:" + err.Error()
@@ -329,7 +320,7 @@ func (n *NodeController) UpdateStorageNodeDisk(ctx *gin.Context) {
 		}
 		ctx.JSON(http.StatusOK, diskReservedRsp)
 	} else {
-		removeDiskReservedRsp, err := n.m.StorageNodeController().RemoveReserveStorageNodeDisk(queryPage, n.diskHandler)
+		removeDiskReservedRsp, err := n.m.StorageNodeController().RemoveReserveStorageNodeDisk(queryPage)
 		if err != nil {
 			failRsp.ErrCode = 500
 			failRsp.Desc = "ReserveStorageNodeDisk Failed:" + err.Error()
@@ -390,7 +381,7 @@ func (n *NodeController) SetStorageNodeDiskOwner(ctx *gin.Context) {
 	queryPage.Owner = owner
 
 	//if owner is system, can`t change owner
-	ownerRspBody, err := n.m.StorageNodeController().SetStorageNodeDiskOwner(queryPage, n.diskHandler)
+	ownerRspBody, err := n.m.StorageNodeController().SetStorageNodeDiskOwner(queryPage)
 	if err != nil {
 		failRsp.ErrCode = 500
 		failRsp.Desc = "ReserveStorageNodeDisk Failed:" + err.Error()
@@ -434,7 +425,7 @@ func (n *NodeController) GetStorageNodeDisk(ctx *gin.Context) {
 	queryPage.NodeName = nodeName
 	queryPage.DiskName = diskName
 
-	localDiskInfo, err := n.m.StorageNodeController().GetStorageNodeDisk(queryPage, n.diskHandler)
+	localDiskInfo, err := n.m.StorageNodeController().GetStorageNodeDisk(queryPage)
 	if err != nil {
 		failRsp.ErrCode = 500
 		failRsp.Desc = "GetStorageNodeDisk Failed:" + err.Error()
@@ -483,7 +474,7 @@ func (n *NodeController) StorageNodePoolsList(ctx *gin.Context) {
 	queryPage.Page = int32(p)
 	queryPage.PageSize = int32(ps)
 
-	storagePoolList, err := n.m.StorageNodeController().StorageNodePoolsList(queryPage, n.diskHandler)
+	storagePoolList, err := n.m.StorageNodeController().StorageNodePoolsList(queryPage)
 	if err != nil {
 		failRsp.ErrCode = 500
 		failRsp.Desc = "StorageNodePoolsList Failed:" + err.Error()
@@ -525,7 +516,7 @@ func (n *NodeController) StorageNodePoolGet(ctx *gin.Context) {
 	queryPage.NodeName = nodeName
 	queryPage.PoolName = poolName
 
-	storagePool, err := n.m.StorageNodeController().StorageNodePoolGet(queryPage, n.diskHandler)
+	storagePool, err := n.m.StorageNodeController().StorageNodePoolGet(queryPage)
 	if err != nil {
 		failRsp.ErrCode = 500
 		failRsp.Desc = "StorageNodePoolGet Failed:" + err.Error()
@@ -568,7 +559,7 @@ func (n *NodeController) StorageNodePoolDisksList(ctx *gin.Context) {
 	queryPage.NodeName = nodeName
 	queryPage.PoolName = poolName
 
-	localDisksItemsList, err := n.m.StorageNodeController().StorageNodePoolDisksList(queryPage, n.diskHandler)
+	localDisksItemsList, err := n.m.StorageNodeController().StorageNodePoolDisksList(queryPage)
 	if err != nil {
 		failRsp.ErrCode = 500
 		failRsp.Desc = "StorageNodePoolDisksList Failed:" + err.Error()
@@ -615,7 +606,7 @@ func (n *NodeController) StorageNodePoolDiskGet(ctx *gin.Context) {
 	queryPage.DiskName = diskName
 	queryPage.PoolName = poolName
 
-	localDiskInfo, err := n.m.StorageNodeController().StorageNodePoolDiskGet(queryPage, n.diskHandler)
+	localDiskInfo, err := n.m.StorageNodeController().StorageNodePoolDiskGet(queryPage)
 	if err != nil {
 		failRsp.ErrCode = 500
 		failRsp.Desc = "StorageNodePoolDiskGet Failed:" + err.Error()

--- a/pkg/apiserver/manager/manager.go
+++ b/pkg/apiserver/manager/manager.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"github.com/hwameistor/hwameistor/pkg/local-disk-manager/handler/localdisk"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -41,6 +42,10 @@ func (m *ServerManager) StorageNodeController() *hwameistorctr.LocalStorageNodeC
 	var recorder record.EventRecorder
 	if m.lsnController == nil {
 		m.lsnController = hwameistorctr.NewLocalStorageNodeController(m.mgr.GetClient(), m.clientset, recorder)
+		// set localdisk handler
+		localDiskRecorder := m.mgr.GetEventRecorderFor("apiserver-localdisk-controller")
+		diskHandler := localdisk.NewLocalDiskHandler(m.mgr.GetClient(), localDiskRecorder)
+		m.lsnController.SetLdHandler(diskHandler)
 	}
 	return m.lsnController
 }

--- a/pkg/apiserver/router/router.go
+++ b/pkg/apiserver/router/router.go
@@ -31,7 +31,7 @@ var (
 func CollectRoute(r *gin.Engine) *gin.Engine {
 	log.Info("CollectRoute start ...")
 
-	sm, m := BuildServerMgr()
+	sm, _ := BuildServerMgr()
 	v1 := r.Group("/apis/hwameistor.io/v1alpha1")
 
 	authController := controller.NewAuthController(sm)
@@ -85,7 +85,7 @@ func CollectRoute(r *gin.Engine) *gin.Engine {
 	ldnController := controller.NewLocalDiskNodeController(sm)
 	v1.GET("/cluster/localdisknodes", ldnController.LocalDiskNodeList)
 
-	nodeController := controller.NewNodeController(sm, m)
+	nodeController := controller.NewNodeController(sm)
 	v1.GET("/cluster/nodes", nodeController.StorageNodeList)
 	v1.GET("/cluster/nodes/:nodeName", nodeController.StorageNodeGet)
 	v1.GET("/cluster/nodes/:nodeName/migrates", nodeController.StorageNodeMigrateGet)

--- a/pkg/hwameictl/cmdparser/disk/disk_reserve.go
+++ b/pkg/hwameictl/cmdparser/disk/disk_reserve.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hwameistor/hwameistor/pkg/apiserver/api"
 	"github.com/hwameistor/hwameistor/pkg/hwameictl/manager"
-	"github.com/hwameistor/hwameistor/pkg/local-disk-manager/handler/localdisk"
 )
 
 var diskReserve = &cobra.Command{
@@ -25,7 +24,6 @@ func diskReserveRunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	diskHandler := localdisk.NewLocalDiskHandler(c.Client, c.EventRecorder)
 	// Build the query parameters
 	parameters := api.QueryPage{
 		NodeName:        args[0],
@@ -35,11 +33,11 @@ func diskReserveRunE(_ *cobra.Command, args []string) error {
 	switch args[2] {
 	case "true":
 		// Set the disk reserved
-		_, err = c.ReserveStorageNodeDisk(parameters, diskHandler)
+		_, err = c.ReserveStorageNodeDisk(parameters)
 		return err
 	case "false":
 		// Set the disk unreserved
-		_, err = c.RemoveReserveStorageNodeDisk(parameters, diskHandler)
+		_, err = c.RemoveReserveStorageNodeDisk(parameters)
 		return err
 	}
 	return fmt.Errorf("the `reserve` parameter should be true/false")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
move `ldHandler` from  `NodeController` to `LocalStorageNodeController`  for improving code cohesion. `ldHandler` located on `NodeController` is useless，because  `NodeController` just deal with checking request parameter and responsing to the client. Instead, `LocalStorageNodeController`  which served as a service layer is a better place for `ldHandler`
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
