### PR TITLE
fix(apiserver): getAvailableDiskCapacity found an empty capacity

### DIFF
--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
@@ -273,12 +273,18 @@ func (lsnController *LocalStorageNodeController) getAvailableDiskCapacity(nodeNa
 	nodeKey := client.ObjectKey{
 		Name: nodeName,
 	}
+
 	if lsn, err := lsnController.GetLocalStorageNode(nodeKey); err != nil {
+		log.Errorf("GetLocalStorageNode err = %v", err)
+	} else {
 		for _, pool := range lsn.Status.Pools {
 			if pool.Class == diskClass {
 				for _, disk := range pool.Disks {
 					if disk.DevPath == devPath {
 						availableDiskCapacity = disk.CapacityBytes
+						log.WithField("availableDiskCapacity", availableDiskCapacity).WithField("devPath", devPath).
+							WithField("diskClass", diskClass).WithField("nodeName", nodeName).
+							Info("availableDiskCapacity is found")
 						break
 					}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
fix(apiserver): getAvailableDiskCapacity found an empty capacity.In the original code,it find the `disk.CapacityBytes` when `GetLocalStorageNode` return the localstoragenode with an error(e.g. localstoragenode not found), so need to change the logic to find the `disk.CapacityBytes` when the `GetLocalStorageNode` return localstoragenode with no errors.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
