### PR TITLE
add lvg node update logic when localvolume access node was updated

### DIFF
--- a/pkg/local-storage/member/controller/volumegroup/manager.go
+++ b/pkg/local-storage/member/controller/volumegroup/manager.go
@@ -578,7 +578,8 @@ func (m *manager) addLocalVolume(lv *apisv1alpha1.LocalVolume) error {
 				lv.Spec.Accessibility.DeepCopyInto(&lvg.Spec.Accessibility)
 				return m.apiClient.Update(context.TODO(), lvg, &client.UpdateOptions{})
 			}
-			return nil
+			// try to update lvg access node if possible
+			return m.updateLocalVolumeGroupAccessibility(lvg)
 		}
 		if vol.PersistentVolumeClaimName == lv.Spec.PersistentVolumeClaimName && lvg.Spec.Namespace == lv.Spec.PersistentVolumeClaimNamespace {
 			// localvolume is just created to serve PVC


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
As of now, actually when the LocalVolumeConvert was applied, the LocalVolumeGroup without an update automaticlly. So when the LocalVolume is updated, LocalVolumeGroupController need to check the LocalVolumeAccessNode and try to sync with the LocalVolumeGroup.
fix part of #1276 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
