### PR TITLE
fix bug pending when pruning replica for localvolumemigrate

### DIFF
--- a/pkg/local-storage/member/controller/volume_migrate_task_worker.go
+++ b/pkg/local-storage/member/controller/volume_migrate_task_worker.go
@@ -309,7 +309,8 @@ func (m *manager) volumeMigratePruneReplica(migrate *apisv1alpha1.LocalVolumeMig
 	ctx := context.TODO()
 
 	// check if source volume can be pruned safely
-	{
+	// configmap will only be created for localvolumemigrate belongs to nonConvertible localvolume
+	if !vol.Spec.Convertible {
 		cm := &corev1.ConfigMap{}
 		cmName := datacopy.GetConfigMapName(datacopy.SyncConfigMapName, migrate.Spec.VolumeName)
 		if err := m.apiClient.Get(ctx, types.NamespacedName{Namespace: m.namespace, Name: cmName}, cm); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
if LocalVolume is convertible, ConfigMap will not be created for localvolumemigrate, so we should not check ConfigMap when pruning replica
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
