### PR TITLE
change client type for supporting fake client to test

### DIFF
--- a/pkg/local-disk-manager/builder/localdisknode/Kubernetes.go
+++ b/pkg/local-disk-manager/builder/localdisknode/Kubernetes.go
@@ -2,20 +2,17 @@ package localdisknode
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	clientset "github.com/hwameistor/hwameistor/pkg/apis/client/clientset/versioned"
+	"github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-
-	clientset "github.com/hwameistor/hwameistor/pkg/apis/client/clientset/versioned"
-	"github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Kubeclient struct {
 	// clientset
-	clientset *clientset.Clientset
-
+	clientset clientset.Interface
 	// kubeConfigPath
 	//	kubeConfigPath string
 }
@@ -66,4 +63,7 @@ func (k *Kubeclient) Patch(ldnOld, ldnNew *v1alpha1.LocalDiskNode) error {
 	}
 	_, err = k.clientset.HwameistorV1alpha1().LocalDiskNodes().Patch(context.Background(), ldnNew.GetName(), patch.Type(), patchData, v1.PatchOptions{})
 	return err
+}
+func (k *Kubeclient) SetClient(cli clientset.Interface) {
+	k.clientset = cli
 }

--- a/pkg/local-disk-manager/builder/localdiskvolume/Kubernetes.go
+++ b/pkg/local-disk-manager/builder/localdiskvolume/Kubernetes.go
@@ -13,7 +13,7 @@ import (
 
 type Kubeclient struct {
 	// clientset
-	clientset *clientset.Clientset
+	clientset clientset.Interface
 
 	// kubeConfigPath
 	//kubeConfigPath string
@@ -48,4 +48,7 @@ func (k *Kubeclient) Get(name string) (*v1alpha1.LocalDiskVolume, error) {
 
 func (k *Kubeclient) Update(volume *v1alpha1.LocalDiskVolume) (*v1alpha1.LocalDiskVolume, error) {
 	return k.clientset.HwameistorV1alpha1().LocalDiskVolumes().Update(context.Background(), volume, v1.UpdateOptions{})
+}
+func (k *Kubeclient) SetClient(cli clientset.Interface) {
+	k.clientset = cli
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
The origin type `*clientset.Clientset` is a subclass of `clientset.Interface` and `*clientset.Clientset` is not supported to use a fake client to test.It may cause further development more hard. So I suppose to modify it to an Interface type,for further testing and development.
https://github.com/hwameistor/hwameistor/blob/138f2456ee38706e3e3b4d2a19852fb32257b0a5/pkg/local-disk-manager/builder/localdisknode/Kubernetes.go#L15-L17
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
