### PR TITLE
remove meaningless poolType using

### DIFF
--- a/pkg/local-storage/member/controller/scheduler/resources.go
+++ b/pkg/local-storage/member/controller/scheduler/resources.go
@@ -247,7 +247,7 @@ func (r *resources) getAssociatedVolumes(vol *apisv1alpha1.LocalVolume) map[stri
 
 		poolName, err := utils.BuildStoragePoolName(
 			sc.Parameters[apisv1alpha1.VolumeParameterPoolClassKey],
-			sc.Parameters[apisv1alpha1.VolumeParameterPoolTypeKey])
+			)
 		if err != nil {
 			r.logger.WithError(err).Errorf("build storagepoolname err")
 			return lvs

--- a/pkg/local-storage/member/csi/controller.go
+++ b/pkg/local-storage/member/csi/controller.go
@@ -356,7 +356,7 @@ func constructLocalVolumeForPVC(pvc *corev1.PersistentVolumeClaim, sc *storagev1
 	lv := apisv1alpha1.LocalVolume{}
 	poolName, err := buildStoragePoolName(
 		sc.Parameters[apisv1alpha1.VolumeParameterPoolClassKey],
-		sc.Parameters[apisv1alpha1.VolumeParameterPoolTypeKey])
+		)
 	if err != nil {
 		return nil, err
 	}
@@ -372,15 +372,15 @@ func constructLocalVolumeForPVC(pvc *corev1.PersistentVolumeClaim, sc *storagev1
 	return &lv, nil
 }
 
-func buildStoragePoolName(poolClass string, poolType string) (string, error) {
+func buildStoragePoolName(poolClass string) (string, error) {
 
-	if poolClass == apisv1alpha1.DiskClassNameHDD && poolType == apisv1alpha1.PoolTypeRegular {
+	if poolClass == apisv1alpha1.DiskClassNameHDD {
 		return apisv1alpha1.PoolNameForHDD, nil
 	}
-	if poolClass == apisv1alpha1.DiskClassNameSSD && poolType == apisv1alpha1.PoolTypeRegular {
+	if poolClass == apisv1alpha1.DiskClassNameSSD {
 		return apisv1alpha1.PoolNameForSSD, nil
 	}
-	if poolClass == apisv1alpha1.DiskClassNameNVMe && poolType == apisv1alpha1.PoolTypeRegular {
+	if poolClass == apisv1alpha1.DiskClassNameNVMe {
 		return apisv1alpha1.PoolNameForNVMe, nil
 	}
 

--- a/pkg/local-storage/member/csi/parser.go
+++ b/pkg/local-storage/member/csi/parser.go
@@ -35,11 +35,7 @@ func parseParameters(req *csi.CreateVolumeRequest) (*volumeParameters, error) {
 	if !ok {
 		return nil, fmt.Errorf("not found pool class")
 	}
-	poolType, ok := params[apisv1alpha1.VolumeParameterPoolTypeKey]
-	if !ok {
-		return nil, fmt.Errorf("not found pool type")
-	}
-	poolName, err := utils.BuildStoragePoolName(poolClass, poolType)
+	poolName, err := utils.BuildStoragePoolName(poolClass)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +77,7 @@ func parseParameters(req *csi.CreateVolumeRequest) (*volumeParameters, error) {
 
 	return &volumeParameters{
 		poolClass:     poolClass,
-		poolType:      poolType,
+		// poolType:      poolType,
 		poolName:      poolName,
 		replicaNumber: int64(replicaNumber),
 		convertible:   convertible,

--- a/pkg/local-storage/member/node/local_disk_claim_task_worker.go
+++ b/pkg/local-storage/member/node/local_disk_claim_task_worker.go
@@ -148,7 +148,7 @@ func (m *manager) processLocalDiskClaimBound(claim *apisv1alpha1.LocalDiskClaim)
 	}
 
 	// 3. record claim and disks backing this claim to StorageNode
-	pool, _ := utils.BuildStoragePoolName(claim.Spec.Description.DiskType, apisv1alpha1.PoolTypeRegular)
+	pool, _ := utils.BuildStoragePoolName(claim.Spec.Description.DiskType)
 	if err = m.storageMgr.Registry().UpdatePoolExtendRecord(pool, claim.Spec); err != nil {
 		logCtx.WithError(err).Error("Failed to UpdatePoolExtendRecord")
 		m.recorder.Eventf(claim, v1.EventTypeWarning, apisv1alpha1.LocalDiskClaimEventReasonConsumedFail,

--- a/pkg/local-storage/utils/utils.go
+++ b/pkg/local-storage/utils/utils.go
@@ -149,14 +149,14 @@ func ConvertBytesToStr(size int64) string {
 }
 
 // BuildStoragePoolName constructs storage pool name
-func BuildStoragePoolName(poolClass string, poolType string) (string, error) {
-	if poolClass == apisv1alpha1.DiskClassNameHDD && poolType == apisv1alpha1.PoolTypeRegular {
+func BuildStoragePoolName(poolClass string) (string, error) {
+	if poolClass == apisv1alpha1.DiskClassNameHDD {
 		return apisv1alpha1.PoolNameForHDD, nil
 	}
-	if poolClass == apisv1alpha1.DiskClassNameSSD && poolType == apisv1alpha1.PoolTypeRegular {
+	if poolClass == apisv1alpha1.DiskClassNameSSD {
 		return apisv1alpha1.PoolNameForSSD, nil
 	}
-	if poolClass == apisv1alpha1.DiskClassNameNVMe && poolType == apisv1alpha1.PoolTypeRegular {
+	if poolClass == apisv1alpha1.DiskClassNameNVMe {
 		return apisv1alpha1.PoolNameForNVMe, nil
 	}
 

--- a/pkg/local-storage/utils/utils_test.go
+++ b/pkg/local-storage/utils/utils_test.go
@@ -48,7 +48,7 @@ func TestBuildStoragePoolName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildStoragePoolName(tt.args.poolClass, tt.args.poolType)
+			got, err := BuildStoragePoolName(tt.args.poolClass)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildStoragePoolName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/scheduler/scheduler/scheduler-lvm.go
+++ b/pkg/scheduler/scheduler/scheduler-lvm.go
@@ -104,7 +104,7 @@ func (s *LVMVolumeScheduler) scoreOneVolume(pvc *corev1.PersistentVolumeClaim, n
 
 	volumeClass := relatedSC.Parameters[v1alpha1.VolumeParameterPoolClassKey]
 	volumeCapacity := pvc.Spec.Resources.Requests.Storage().Value()
-	poolClass, err := buildStoragePoolName(volumeClass, v1alpha1.PoolTypeRegular)
+	poolClass, err := buildStoragePoolName(volumeClass)
 	if err != nil {
 		return 0, err
 	}
@@ -307,7 +307,7 @@ func (s *LVMVolumeScheduler) constructLocalVolumeForPVC(pvc *corev1.PersistentVo
 	localVolume := v1alpha1.LocalVolume{}
 	poolName, err := buildStoragePoolName(
 		sc.Parameters[v1alpha1.VolumeParameterPoolClassKey],
-		sc.Parameters[v1alpha1.VolumeParameterPoolTypeKey])
+		)
 	if err != nil {
 		return nil, err
 	}
@@ -346,15 +346,15 @@ func (s *LVMVolumeScheduler) getSourceVolumeFromSnapshot(vsNamespace, vsName str
 	return &localVolume, nil
 }
 
-func buildStoragePoolName(poolClass string, poolType string) (string, error) {
+func buildStoragePoolName(poolClass string) (string, error) {
 
-	if poolClass == v1alpha1.DiskClassNameHDD && poolType == v1alpha1.PoolTypeRegular {
+	if poolClass == v1alpha1.DiskClassNameHDD {
 		return v1alpha1.PoolNameForHDD, nil
 	}
-	if poolClass == v1alpha1.DiskClassNameSSD && poolType == v1alpha1.PoolTypeRegular {
+	if poolClass == v1alpha1.DiskClassNameSSD {
 		return v1alpha1.PoolNameForSSD, nil
 	}
-	if poolClass == v1alpha1.DiskClassNameNVMe && poolType == v1alpha1.PoolTypeRegular {
+	if poolClass == v1alpha1.DiskClassNameNVMe {
 		return v1alpha1.PoolNameForNVMe, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
poolType is meaningless, we decide to remote it and we don't need to write it in storageclass's spec.parameters anymore.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
