### PR TITLE
improve(apiserver):check LocalDisks length when ListLocalDiskByNodeDevicePath returns

### DIFF
--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
@@ -491,6 +491,10 @@ func (lsnController *LocalStorageNodeController) SetStorageNodeDiskOwner(queryPa
 		log.Errorf("failed to get localDisk %s", err.Error())
 		return RspBody, err
 	}
+	if len(localDisks) == 0 {
+		log.WithField("nodeName", queryPage.NodeName).WithField("devPath", hwameistorapi.DEV+queryPage.DeviceShortPath).Errorf("no localdisks found")
+		return RspBody, fmt.Errorf("no localdisks found,nodeName:%v,devPath:%v", queryPage.NodeName, hwameistorapi.DEV+queryPage.DeviceShortPath)
+	}
 	ld := &localDisks[0]
 	//Unable to operate the operating system disk
 	if ld.Spec.Owner != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
improve lsn-controller for programming robustness. The return length of `ListLocalDiskByNodeDevicePath` need to be checked not equal to zero.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
