### PR TITLE
fix(apiserver): fix StorageNodeList api

### DIFF
--- a/pkg/apiserver/api/node.go
+++ b/pkg/apiserver/api/node.go
@@ -8,7 +8,6 @@ import (
 
 type StorageNode struct {
 	LocalStorageNode apisv1alpha1.LocalStorageNode `json:"localStorageNode,omitempty"`
-	LocalDiskNode    apisv1alpha1.LocalDiskNode    `json:"localDiskNode,omitempty"`
 	TotalDisk        int                           `json:"totalDisk,omitempty"`
 	K8sNode          *k8sv1.Node
 	K8sNodeState     State `json:"k8SNodeState,omitempty"`

--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
@@ -100,12 +100,6 @@ func (lsnController *LocalStorageNodeController) ListLocalStorageNode(queryPage 
 		var sn = &hwameistorapi.StorageNode{}
 
 		sn.LocalStorageNode = lsnList.Items[i]
-		localDiskNode, err := lsnController.GetLocalDiskNode(lsnList.Items[i].Name)
-		if err != nil {
-			log.WithError(err).Error("Failed to get localDiskNode")
-			return nil, err
-		}
-
 		if queryPage.PoolName != "" {
 			for _, pool := range lsnList.Items[i].Status.Pools {
 				if pool.Name == queryPage.PoolName {
@@ -114,7 +108,7 @@ func (lsnController *LocalStorageNodeController) ListLocalStorageNode(queryPage 
 			}
 		}
 
-		sn.LocalDiskNode = *localDiskNode
+		sn.LocalStorageNode = lsnList.Items[i]
 		k8sNode, K8sNodeState := lsnController.getK8SNode(lsnList.Items[i].Name)
 		sn.K8sNode = k8sNode
 		sn.K8sNodeState = K8sNodeState


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
The StorageNodeList API returns a LocalDiskNode infomation but not a LocalStorageNode information. It is not a reasonable result in StorageNode API
fix #1328 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
