### PR TITLE
set volumes in localvolumemigrate.status to omitempty

### DIFF
--- a/deploy/crds/hwameistor.io_localvolumemigrates_crd.yaml
+++ b/deploy/crds/hwameistor.io_localvolumemigrates_crd.yaml
@@ -98,8 +98,6 @@ spec:
                 items:
                   type: string
                 type: array
-            required:
-            - volumes
             type: object
         type: object
     served: true

--- a/pkg/apis/hwameistor/v1alpha1/localvolumemigrate_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localvolumemigrate_types.go
@@ -49,7 +49,7 @@ type LocalVolumeMigrateStatus struct {
 	// record the node where the specified replica is migrated to
 	TargetNode string `json:"targetNode,omitempty"`
 	// record all the volumes to be migrated
-	Volumes []string `json:"volumes"`
+	Volumes []string `json:"volumes,omitempty"`
 
 	// State of the operation, e.g. submitted, started, completed, abort, ...
 	State State `json:"state,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
there is a problem when we want to abort a localvolumemigrate of which status.volumes is nill by kubectl, we can't commit when execute kubectl edit, this pr fix the problem.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
