### PR TITLE
add PoolHDD FreeCap print column

### DIFF
--- a/deploy/crds/hwameistor.io_localstoragenodes_crd.yaml
+++ b/deploy/crds/hwameistor.io_localstoragenodes_crd.yaml
@@ -22,6 +22,21 @@ spec:
       jsonPath: .status.state
       name: status
       type: string
+    - description: Free Capacity bytes in HDD Pool
+      jsonPath: .status.pools.LocalStorage_PoolHDD.freeCapacityBytes
+      name: PoolHDD FreeCap
+      priority: 1
+      type: integer
+    - description: Free Capacity bytes in SSD Pool
+      jsonPath: .status.pools.LocalStorage_PoolSSD.freeCapacityBytes
+      name: PoolSSD FreeCap
+      priority: 1
+      type: integer
+    - description: Free Capacity bytes in NVMe Pool
+      jsonPath: .status.pools.LocalStorage_PoolNVMe.freeCapacityBytes
+      name: PoolNVMe FreeCap
+      priority: 1
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date

--- a/pkg/apis/hwameistor/v1alpha1/localstoragenode_types.go
+++ b/pkg/apis/hwameistor/v1alpha1/localstoragenode_types.go
@@ -163,6 +163,9 @@ type LocalDevice struct {
 // +kubebuilder:resource:path=localstoragenodes,scope=Cluster,shortName=lsn
 // +kubebuilder:printcolumn:name="ip",type=string,JSONPath=`.spec.storageIP`,description="IPv4 address"
 // +kubebuilder:printcolumn:name="status",type=string,JSONPath=`.status.state`,description="State of the Local Storage Node"
+// +kubebuilder:printcolumn:name="PoolHDD FreeCap",type=integer,JSONPath=`.status.pools.LocalStorage_PoolHDD.freeCapacityBytes`,description="Free Capacity bytes in HDD Pool",priority=1
+// +kubebuilder:printcolumn:name="PoolSSD FreeCap",type=integer,JSONPath=`.status.pools.LocalStorage_PoolSSD.freeCapacityBytes`,description="Free Capacity bytes in SSD Pool",priority=1
+// +kubebuilder:printcolumn:name="PoolNVMe FreeCap",type=integer,JSONPath=`.status.pools.LocalStorage_PoolNVMe.freeCapacityBytes`,description="Free Capacity bytes in NVMe Pool",priority=1
 // +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`
 type LocalStorageNode struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
To offer free capacity information for system manager.
#### Special notes for your reviewer:
Kubectl Output Samples:
```shell
$ k get lsn -owide
NAME      IP            STATUS   POOLHDD FREECAP   POOLSSD FREECAP   POOLNVME FREECAP   AGE
master1   10.6.118.30   Ready                                                           16d
node1     10.6.118.31   Ready    15028191232                                            16d
node2     10.6.118.32   Ready                                                           16d
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add StoragePool FreeCapacity in kubectl print column
```
