### PR TITLE
fix(CI): bump go version to 1.20.5 in module and builder

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:alpine
+FROM golang:1.21.5-alpine

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.21.5-alpine
 
 # set mirror repository for the package management
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/' /etc/apk/repositories

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hwameistor/hwameistor
 
-go 1.18
+go 1.20
 
 require (
 	github.com/operator-framework/operator-sdk v0.18.2


### PR DESCRIPTION
…023-24538

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
fix CVE-2023-24538, CVE-2023-24540
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
