### PR TITLE
fix(scheduler): correct skip policy for affinity and taints

### DIFF
--- a/pkg/local-storage/member/controller/scheduler/scheduler_test.go
+++ b/pkg/local-storage/member/controller/scheduler/scheduler_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
-	v1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
+	"github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
 	vgmock "github.com/hwameistor/hwameistor/pkg/local-storage/member/controller/volumegroup"
 )
 
@@ -398,9 +398,9 @@ func TestIsTaintMatch(t *testing.T) {
 				},
 			}
 
-			match := isTaintMatch(node, tt.tolerations)
+			match := canTaintBeTolerated(node, tt.tolerations)
 			if match != tt.expectedMatch {
-				t.Errorf("isTaintMatch() = %v, want %v", match, tt.expectedMatch)
+				t.Errorf("canTaintBeTolerated() = %v, want %v", match, tt.expectedMatch)
 			}
 		})
 	}

--- a/pkg/local-storage/member/controller/scheduler/scheduler_test.go
+++ b/pkg/local-storage/member/controller/scheduler/scheduler_test.go
@@ -299,7 +299,7 @@ func TestIsTaintMatch(t *testing.T) {
 				},
 			},
 			tolerations:   []corev1.Toleration{},
-			expectedMatch: true,
+			expectedMatch: false,
 		},
 		{
 			name:       "taints empty, tolerations present",
@@ -387,6 +387,39 @@ func TestIsTaintMatch(t *testing.T) {
 				},
 			},
 			expectedMatch: false,
+		},
+		{
+			name: "single node with PreferNoSchedule taint, pod without tolerations",
+			nodeTaints: []corev1.Taint{
+				{
+					Key:    "key1",
+					Value:  "value1",
+					Effect: corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			tolerations: []corev1.Toleration{},
+			// If there is only one node, the Pod should be scheduled to this node even if it has no toleration.
+			expectedMatch: true,
+		},
+
+		{
+			name: "single node with PreferNoSchedule taint, pod with mismatched tolerations",
+			nodeTaints: []corev1.Taint{
+				{
+					Key:    "key1",
+					Value:  "value1",
+					Effect: corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "key2", // Key Mismatch
+					Operator: corev1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			expectedMatch: true,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Fix blow errors:

1. `hwameistor.io/skip-affinity-annotations` specified in pvc but not take effect
2. node that has `PrefferNoSchedule` taint but being filtered out

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
