### PR TITLE
local-disk-manager: Add GET_VOLUME_STATS capability

### DIFF
--- a/pkg/local-disk-manager/csi/driver/node/node.go
+++ b/pkg/local-disk-manager/csi/driver/node/node.go
@@ -28,10 +28,6 @@ type Config struct {
 	NodeName string `json:"nodeName"`
 }
 
-const (
-	_DFCmd = "df"
-)
-
 func NewServer() *Server {
 	server := &Server{}
 	server.initConfig()

--- a/pkg/local-disk-manager/csi/driver/node/node.go
+++ b/pkg/local-disk-manager/csi/driver/node/node.go
@@ -3,6 +3,9 @@ package node
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	volume "github.com/hwameistor/hwameistor/pkg/local-disk-manager/member/controller/volume"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -25,6 +28,10 @@ type Config struct {
 	NodeName string `json:"nodeName"`
 }
 
+const (
+	_DFCmd = "df"
+)
+
 func NewServer() *Server {
 	server := &Server{}
 	server.initConfig()
@@ -39,7 +46,7 @@ func (s *Server) initConfig() {
 
 func (s *Server) initNodeCapabilities() {
 	caps := []csi.NodeServiceCapability_RPC_Type{
-		//NodeServiceCapability_RPC_GET_VOLUME_STATS,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 		//NodeServiceCapability_RPC_VOLUME_CONDITION,
 	}
 	for _, c := range caps {
@@ -82,7 +89,64 @@ func (s *Server) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 }
 
 func (s *Server) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+	vol, err := s.vm.GetVolumeInfo(req.VolumeId)
+	if err != nil {
+		return nil, fmt.Errorf("volume %s not found: %v", req.VolumeId, err)
+	}
+
+	ready, err := s.vm.VolumeIsReady(req.VolumeId)
+	if err != nil || !ready {
+		return &csi.NodeGetVolumeStatsResponse{
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: true,
+				Message:  "Volume is not ready",
+			},
+		}, nil
+	}
+
+	args := []string{"--output=size,used,avail,itotal,iused,iavail", "--block-size=1", vol.AttachPath}
+	out, err := utils.BashWithArgs("df", args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute df command: %v", err)
+	}
+
+	lines := strings.Split(string(out), "\n")
+	if len(lines) < 2 {
+		return nil, fmt.Errorf("unexpected df output format")
+	}
+
+	fields := strings.Fields(lines[1])
+	if len(fields) != 6 {
+		return nil, fmt.Errorf("unexpected number of fields in df output")
+	}
+
+	total, _ := strconv.ParseInt(fields[0], 10, 64)
+	used, _ := strconv.ParseInt(fields[1], 10, 64)
+	free, _ := strconv.ParseInt(fields[2], 10, 64)
+	iTotal, _ := strconv.ParseInt(fields[3], 10, 64)
+	iUsed, _ := strconv.ParseInt(fields[4], 10, 64)
+	iFree, _ := strconv.ParseInt(fields[5], 10, 64)
+
+	return &csi.NodeGetVolumeStatsResponse{
+		VolumeCondition: &csi.VolumeCondition{
+			Abnormal: false,
+			Message:  "Volume is ready",
+		},
+		Usage: []*csi.VolumeUsage{
+			{
+				Unit:      csi.VolumeUsage_BYTES,
+				Total:     total,
+				Available: free,
+				Used:      used,
+			},
+			{
+				Unit:      csi.VolumeUsage_INODES,
+				Total:     iTotal,
+				Available: iFree,
+				Used:      iUsed,
+			},
+		},
+	}, nil
 }
 
 func (s *Server) NodeExpandVolume(context.Context, *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {

--- a/pkg/local-disk-manager/csi/driver/node/node.go
+++ b/pkg/local-disk-manager/csi/driver/node/node.go
@@ -43,7 +43,7 @@ func (s *Server) initConfig() {
 func (s *Server) initNodeCapabilities() {
 	caps := []csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
-		//NodeServiceCapability_RPC_VOLUME_CONDITION,
+		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
 	}
 	for _, c := range caps {
 		s.supportNodeCapability = append(s.supportNodeCapability, newNodeServiceCapability(c))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Fixes #1603 

#### Special notes for your reviewer:
I don't have a testing setup, I am happy to receive some info on what's the best way to test it, but I would also appreciate if you (as the reviewer) test it because I don't have a local dev setup to run a dev k8s cluster and for unit tests I've never written go tests in my life. In fact this is the first time I wrote go.

Also, just to set expectations, I just did this quickly in 20-30 minutes but I don't have a lot of time to refine the implementation. If this is a totally stupid way to go about it, feel free to close the PR, the issue is open so maybe somebody more competent will provide a more idiomatic implementation.

I also added a flake.nix. Nix flakes are an increasingly common way to manager development environments. I am one of thousdands or millions of developers who use nix for all devenvs. Notably companies such as [Google](https://idx.dev) or Replit bet on nix as well.

#### Does this PR introduce a user-facing change?
```release-note
Add kubelet volume stats for local-disk-manager volumes
```
