### PR TITLE
Added configuration snapshot restore time, default is 10 minutes

### DIFF
--- a/cmd/local-storage/storage.go
+++ b/cmd/local-storage/storage.go
@@ -50,6 +50,7 @@ var (
 	logLevel                = flag.Int("v", 4 /*Log Info*/, "number for the log level verbosity")
 	migrateConcurrentNumber = flag.Int("max-migrate-count", 1, "Limit the number of concurrent migrations")
 	migrateDataNeedCheck    = flag.Bool("migrate-check", false, "Enable data verification during data migration")
+	snapshotRestoreTimeout  = flag.Int("snapshot-restore-timeout", 600, "Time to restore VolumeReplica Snapshot，in seconds")
 )
 
 var BUILDVERSION, BUILDTIME, GOVERSION string
@@ -112,6 +113,7 @@ func main() {
 
 	localctrl.MigrateConcurrentNumber = *migrateConcurrentNumber
 	localctrl.MigrateDataNeedCheck = *migrateDataNeedCheck
+	member.SnapshotRestoreTimeout = *snapshotRestoreTimeout
 
 	systemConfig, err := getSystemConfig()
 	if err != nil {

--- a/helm/hwameistor/templates/local-storage.yaml
+++ b/helm/hwameistor/templates/local-storage.yaml
@@ -73,6 +73,9 @@ spec:
         {{- if .Values.localStorage.member.config.maxMigrateCount}}
         - --max-migrate-count={{ .Values.localStorage.member.config.maxMigrateCount }}
         {{- end}}
+        {{- if .Values.localStorage.member.config.snapshotRestoreTimeout}}
+        - --snapshot-restore-timeout={{ .Values.localStorage.member.config.snapshotRestoreTimeout }}
+        {{- end}}
         env:
         - name: POD_NAME
           valueFrom:

--- a/helm/hwameistor/values.yaml
+++ b/helm/hwameistor/values.yaml
@@ -131,6 +131,8 @@ localStorage:
       maxHAVolumeCount: 1000
       #Max LvMigrate count
       maxMigrateCount: 1
+      #Time to restore VolumeReplica Snapshot，in seconds
+      snapshotRestoreTimeout: 600
 
     imageRepository: hwameistor/local-storage
     tag: ""

--- a/pkg/local-storage/member/member.go
+++ b/pkg/local-storage/member/member.go
@@ -20,6 +20,8 @@ import (
 // So, it's a global variable
 var nodeInstance localapis.LocalStorageMember
 
+var SnapshotRestoreTimeout = 60 * 10
+
 // Member gets member instance
 func Member() localapis.LocalStorageMember {
 	if nodeInstance == nil {
@@ -42,6 +44,8 @@ type localStorageMember struct {
 	namespace string
 
 	csiDriverName string
+
+	snapshotRestoreTimeout int
 
 	apiClient client.Client
 
@@ -69,13 +73,14 @@ func (m *localStorageMember) ConfigureBase(name string, namespace string, system
 	m.informersCache = informersCache
 	m.systemConfig = systemConfig
 	m.recorder = recorder
+	m.snapshotRestoreTimeout = SnapshotRestoreTimeout
 	return m
 }
 
 func (m *localStorageMember) ConfigureNode(scheme *runtime.Scheme) localapis.LocalStorageMember {
 	if m.nodeManager == nil {
 		var err error
-		m.nodeManager, err = localnode.New(m.name, m.namespace, m.apiClient, m.informersCache, m.systemConfig, scheme, m.recorder)
+		m.nodeManager, err = localnode.New(m.name, m.namespace, m.apiClient, m.informersCache, m.systemConfig, scheme, m.recorder, m.snapshotRestoreTimeout)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/local-storage/member/node/manager.go
+++ b/pkg/local-storage/member/node/manager.go
@@ -44,6 +44,8 @@ type manager struct {
 
 	namespace string
 
+	snapshotRestoreTimeout int
+
 	apiClient client.Client
 
 	informersCache runtimecache.Cache
@@ -95,7 +97,7 @@ type manager struct {
 
 // New node manager
 func New(name string, namespace string, cli client.Client, informersCache runtimecache.Cache, config apisv1alpha1.SystemConfig,
-	scheme *runtime.Scheme, recorder record.EventRecorder) (apis.NodeManager, error) {
+	scheme *runtime.Scheme, recorder record.EventRecorder, snapshotRestoreTimeout int) (apis.NodeManager, error) {
 	configManager, err := NewConfigManager(name, config, cli)
 	if err != nil {
 		return nil, err
@@ -108,6 +110,7 @@ func New(name string, namespace string, cli client.Client, informersCache runtim
 	return &manager{
 		name:                                  name,
 		namespace:                             namespace,
+		snapshotRestoreTimeout:                snapshotRestoreTimeout,
 		apiClient:                             cli,
 		informersCache:                        informersCache,
 		replicaRecords:                        map[string]string{},
@@ -426,7 +429,7 @@ func (m *manager) register() {
 	}
 	nodeConfig.Name = m.name
 
-	m.storageMgr = storage.NewLocalManager(nodeConfig, m.apiClient, m.scheme, m.recorder)
+	m.storageMgr = storage.NewLocalManager(nodeConfig, m.apiClient, m.scheme, m.recorder, m.snapshotRestoreTimeout)
 	if err := m.storageMgr.Register(); err != nil {
 		logCtx.WithError(err).Fatal("Failed to register node's storage manager")
 	}

--- a/pkg/local-storage/member/node/storage/executor_dd.go
+++ b/pkg/local-storage/member/node/storage/executor_dd.go
@@ -11,8 +11,9 @@ import (
 )
 
 type ddExecutor struct {
-	cmdExec exechelper.Executor
-	logger  *log.Entry
+	cmdExec          exechelper.Executor
+	restoreTimeLimit int
+	logger           *log.Entry
 }
 
 var (
@@ -22,15 +23,15 @@ var (
 
 const (
 	DiskDumpCMD       = "dd"
-	DiskDumpTimeout   = 60 * 10 // seconds
 	DiskDumpBlockSize = "bs=10M"
 )
 
-func newDDExecutor() *ddExecutor {
+func newDDExecutor(restoreTimeLimit int) *ddExecutor {
 	once.Do(func() {
 		ddExecutorInstance = &ddExecutor{
-			cmdExec: nsexecutor.New(),
-			logger:  log.WithField("Module", "NodeManager/ddExecutor"),
+			cmdExec:          nsexecutor.New(),
+			restoreTimeLimit: restoreTimeLimit,
+			logger:           log.WithField("Module", "NodeManager/ddExecutor"),
 		}
 	})
 
@@ -55,7 +56,7 @@ func (dd *ddExecutor) RestoreVolumeReplicaSnapshot(snapshotRestore *apisv1alpha1
 			fmt.Sprintf("of=%s", outPutDevicePath),
 			DiskDumpBlockSize,
 		},
-		Timeout: DiskDumpTimeout,
+		Timeout: dd.restoreTimeLimit,
 	}
 
 	dd.logger.WithField("restoreVolume", outPutDevicePath).Info("Start restoring snapshot")

--- a/pkg/local-storage/member/node/storage/manager.go
+++ b/pkg/local-storage/member/node/storage/manager.go
@@ -10,10 +10,11 @@ import (
 
 // LocalManager struct
 type LocalManager struct {
-	apiClient client.Client
-	scheme    *runtime.Scheme
-	recorder  record.EventRecorder
-	nodeConf  *apisv1alpha1.NodeConfig
+	snapshotRestoreTimeout int
+	apiClient              client.Client
+	scheme                 *runtime.Scheme
+	recorder               record.EventRecorder
+	nodeConf               *apisv1alpha1.NodeConfig
 
 	registry                     LocalRegistry
 	poolManager                  LocalPoolManager
@@ -22,7 +23,7 @@ type LocalManager struct {
 }
 
 // NewLocalManager creates a local manager
-func NewLocalManager(nodeConf *apisv1alpha1.NodeConfig, cli client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *LocalManager {
+func NewLocalManager(nodeConf *apisv1alpha1.NodeConfig, cli client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, snapshotRestoreTimeout int) *LocalManager {
 	lm := &LocalManager{
 		nodeConf:  nodeConf,
 		apiClient: cli,
@@ -33,7 +34,7 @@ func NewLocalManager(nodeConf *apisv1alpha1.NodeConfig, cli client.Client, schem
 	lm.volumeReplicaManager = newLocalVolumeReplicaManager(lm)
 	lm.volumeReplicaSnapshotManager = newLocalVolumeReplicaSnapshotManager(lm)
 	lm.poolManager = newLocalPoolManager(lm)
-
+	lm.snapshotRestoreTimeout = snapshotRestoreTimeout
 	return lm
 }
 

--- a/pkg/local-storage/member/node/storage/snapshot.go
+++ b/pkg/local-storage/member/node/storage/snapshot.go
@@ -14,7 +14,7 @@ type localVolumeReplicaSnapshotManager struct {
 func newLocalVolumeReplicaSnapshotManager(lm *LocalManager) LocalVolumeReplicaSnapshotManager {
 	return &localVolumeReplicaSnapshotManager{
 		cmdExec: newLVMExecutor(lm),
-		ddExec:  newDDExecutor(),
+		ddExec:  newDDExecutor(lm.snapshotRestoreTimeout),
 		logger:  log.WithField("Module", "NodeManager/LocalVolumeReplicaSnapshotManager"),
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
https://github.com/hwameistor/hwameistor/issues/1637
#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
You can modify the snapshot recovery time limit by editing ds：
kubectl -n hwameistor edit ds hwameistor-local-storage
![image](https://github.com/user-attachments/assets/6d0c68e7-8665-4637-a212-300c8e3f150e)
