### PR TITLE
fix: metadata size for pv is configurable now, default is 4MB

### DIFF
--- a/cmd/local-storage/storage.go
+++ b/cmd/local-storage/storage.go
@@ -51,6 +51,7 @@ var (
 	migrateConcurrentNumber = flag.Int("max-migrate-count", 1, "Limit the number of concurrent migrations")
 	migrateDataNeedCheck    = flag.Bool("migrate-check", false, "Enable data verification during data migration")
 	snapshotRestoreTimeout  = flag.Int("snapshot-restore-timeout", 600, "Time to restore VolumeReplica Snapshot，in seconds")
+	pvMetadataSize          = flag.Int("pv-metadata-size", 4*1024*1024, "The size of the metadata of the PV in Bytes, default 4MB")
 )
 
 var BUILDVERSION, BUILDTIME, GOVERSION string
@@ -162,7 +163,7 @@ func main() {
 
 	//initialize the local storage node/member as:
 	log.Info("Configuring the Local Storage Member")
-	storageMember := member.Member().ConfigureBase(*nodeName, *namespace, systemConfig, mgr.GetClient(), mgr.GetCache(),
+	storageMember := member.Member().ConfigureBase(*nodeName, *namespace, systemConfig, *pvMetadataSize, mgr.GetClient(), mgr.GetCache(),
 		mgr.GetEventRecorderFor(fmt.Sprintf("%s/%s", "localstoragemanager", *nodeName))).
 		ConfigureNode(mgr.GetScheme()).
 		ConfigureController(mgr.GetScheme()).

--- a/pkg/apis/hwameistor/local_storage_member.go
+++ b/pkg/apis/hwameistor/local_storage_member.go
@@ -27,7 +27,7 @@ type LocalStorageMember interface {
 	Run(stopCh <-chan struct{})
 
 	// ******  configuration ******* //
-	ConfigureBase(name string, namespace string, haSystemConfig apisv1alpha1.SystemConfig, cli client.Client, informersCache cache.Cache, recorder record.EventRecorder) LocalStorageMember
+	ConfigureBase(name string, namespace string, haSystemConfig apisv1alpha1.SystemConfig, pvMetadataSize int, cli client.Client, informersCache cache.Cache, recorder record.EventRecorder) LocalStorageMember
 
 	ConfigureNode(scheme *runtime.Scheme) LocalStorageMember
 

--- a/pkg/local-storage/controller/localvolume/localvolume_controller_test.go
+++ b/pkg/local-storage/controller/localvolume/localvolume_controller_test.go
@@ -63,7 +63,7 @@ func TestNewLocalVolumeController(t *testing.T) {
 	r := ReconcileLocalVolume{
 		client:        cli,
 		scheme:        s,
-		storageMember: member.Member().ConfigureController(s).ConfigureBase(fakeNodename, fakeNamespace, systemConfig, cli, ca, fakeRecorder).ConfigureNode(s),
+		storageMember: member.Member().ConfigureController(s).ConfigureBase(fakeNodename, fakeNamespace, systemConfig, 0, cli, ca, fakeRecorder).ConfigureNode(s),
 	}
 
 	// Create LocalVolume

--- a/pkg/local-storage/controller/localvolumereplica/localvolumereplica_controller_test.go
+++ b/pkg/local-storage/controller/localvolumereplica/localvolumereplica_controller_test.go
@@ -64,7 +64,7 @@ func TestNewLocalVolumeReplicaController(t *testing.T) {
 	r := ReconcileLocalVolumeReplica{
 		client:        cli,
 		scheme:        s,
-		storageMember: member.Member().ConfigureController(s).ConfigureBase(fakeNodename, fakeNamespace, systemConfig, cli, ca, fakeRecorder).ConfigureNode(s),
+		storageMember: member.Member().ConfigureController(s).ConfigureBase(fakeNodename, fakeNamespace, systemConfig, 0, cli, ca, fakeRecorder).ConfigureNode(s),
 	}
 
 	// Create LocalVolumeReplica

--- a/pkg/local-storage/member/member.go
+++ b/pkg/local-storage/member/member.go
@@ -39,6 +39,8 @@ func newMember() localapis.LocalStorageMember {
 type localStorageMember struct {
 	name string
 
+	pvMetadataSize int
+
 	version string
 
 	namespace string
@@ -64,9 +66,10 @@ type localStorageMember struct {
 	recorder record.EventRecorder
 }
 
-func (m *localStorageMember) ConfigureBase(name string, namespace string, systemConfig apisv1alpha1.SystemConfig,
+func (m *localStorageMember) ConfigureBase(name string, namespace string, systemConfig apisv1alpha1.SystemConfig, pvMetadataSize int,
 	cli client.Client, informersCache cache.Cache, recorder record.EventRecorder) localapis.LocalStorageMember {
 	m.name = name
+	m.pvMetadataSize = pvMetadataSize
 	m.version = localapis.Version
 	m.namespace = namespace
 	m.apiClient = cli
@@ -80,7 +83,7 @@ func (m *localStorageMember) ConfigureBase(name string, namespace string, system
 func (m *localStorageMember) ConfigureNode(scheme *runtime.Scheme) localapis.LocalStorageMember {
 	if m.nodeManager == nil {
 		var err error
-		m.nodeManager, err = localnode.New(m.name, m.namespace, m.apiClient, m.informersCache, m.systemConfig, scheme, m.recorder, m.snapshotRestoreTimeout)
+		m.nodeManager, err = localnode.New(m.name, m.namespace, m.apiClient, m.informersCache, m.systemConfig, scheme, m.recorder, m.snapshotRestoreTimeout, m.pvMetadataSize)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/local-storage/member/node/local_disk_task_worker.go
+++ b/pkg/local-storage/member/node/local_disk_task_worker.go
@@ -148,6 +148,7 @@ func (m *manager) handleDiskStateChange(localDisk *apisv1alpha1.LocalDisk) {
 
 func (m *manager) needResizePVCapacity(currentCapacity, recordCapacity int64) bool {
 	// consider metadata size, the capacity in pv may smaller than actual disk capacity
-	var pe = 4 * 1024 * 1024
-	return math.Abs(float64(currentCapacity-recordCapacity)) > float64(pe)
+	// sometimes the difference between storage-pool capacity and disk capacity is bigger than metadata size
+	// more details can be found in #1660
+	return math.Abs(float64(currentCapacity-recordCapacity)) > float64(m.pvMetadataSize)
 }

--- a/pkg/local-storage/member/node/manager.go
+++ b/pkg/local-storage/member/node/manager.go
@@ -42,6 +42,8 @@ const (
 type manager struct {
 	name string
 
+	pvMetadataSize int
+
 	namespace string
 
 	snapshotRestoreTimeout int
@@ -97,7 +99,7 @@ type manager struct {
 
 // New node manager
 func New(name string, namespace string, cli client.Client, informersCache runtimecache.Cache, config apisv1alpha1.SystemConfig,
-	scheme *runtime.Scheme, recorder record.EventRecorder, snapshotRestoreTimeout int) (apis.NodeManager, error) {
+	scheme *runtime.Scheme, recorder record.EventRecorder, snapshotRestoreTimeout int, pvMetadataSize int) (apis.NodeManager, error) {
 	configManager, err := NewConfigManager(name, config, cli)
 	if err != nil {
 		return nil, err
@@ -131,6 +133,7 @@ func New(name string, namespace string, cli client.Client, informersCache runtim
 		scheme:           scheme,
 		recorder:         recorder,
 		mounter:          csi.NewLinuxMounter(log.WithField("Module", "NodeManager")),
+		pvMetadataSize:   pvMetadataSize,
 	}, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
fix #1660 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
this can be configured from **local-storage** container by `--pv-metadata-size=4194304` param.
```release-note
NONE
```
