### PR TITLE
Address LVG state inconsistencies, resource racing, and typos

### DIFF
--- a/pkg/local-storage/member/controller/volumegroup/manager.go
+++ b/pkg/local-storage/member/controller/volumegroup/manager.go
@@ -560,13 +560,13 @@ func (m *manager) processLocalVolume(lvName string) error {
 	err := m.apiClient.Get(context.TODO(), types.NamespacedName{Name: lvName}, lv)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return m.deleteLocalVolume(lv.Name)
+			return m.deleteLocalVolume(lvName)
 		}
 		return err
 	}
 
-	if lv.Status.State == apisv1alpha1.VolumeStateDeleted {
-		return m.deleteLocalVolume(lv.Name)
+	if lv.Status.State == apisv1alpha1.VolumeStateDeleted || lv.DeletionTimestamp != nil {
+		return m.deleteLocalVolume(lvName)
 	}
 
 	return m.addLocalVolume(lv)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

#### Special notes for your reviewer:

Here are 3 commits in this pr:

https://github.com/hwameistor/hwameistor/commit/6ed14b1dbf79c1b2fabacc2401e2264ae34fb380: The original hwameistor `createVolume` operation was performed serially. When creating a large number of PVCs, the waiting time was relatively long. Therefore, it was later changed to parallel creation. However, the creation process depends on the lvg resource, and parallel creation caused a race for resources. This might lead to inaccurate scheduling in the end. For example, if a pod that uses a large number of PVCs needs to be created now, some PVCs might be scheduled to node A, while others might be scheduled to node B, ultimately causing the pod to fail creation. Therefore, we should add a lock for this resource race and need to wait for the local lvg cache to synchronize.

---

https://github.com/hwameistor/hwameistor/commit/efa755e4abe4f97156098f2c0b2f3dfee683a5f1: This might have been a typo introduced during the development of `lvg`. Recently, while using it, our team encountered unexpected behavior related to `lvg` and spent a of time identifying this subtle issue...

---

https://github.com/hwameistor/hwameistor/commit/9706e9579cf190ba91c82f22edc89e8adef40982:  This is another relatively complex edge case. If I perform the following operations:

1.  Create a PodA with pvcA, which is running.
2.  Create a PodB with pvcB. This pvcB is special: it specifies a `spec.dataSource`, so it doesn't actually require Hwameistor to create an LV. At this point, it's in a pending state, and PodB has not been created yet.

At this stage, there will be two LVGs:
-   lvg1 (localvolume: lvA, pvc: pvcA)
-   lvg2 (localvolume: "", pvc: pvcB)

Subsequently, I delete PodA, and the dataSource controller performs a rebind operation on pvA  to rebind it to pvcB, and then delete pvcA.

After this, because pvcA was deleted, lvg1 is left only with lvA: `lvg1 (localvolume: lvA, pvc: "")`. Even though pvcB is now bound to pvA, lvg2 remains unchanged: `lvg2 (localvolume: "", pvc: pvcB)`. This results in an inconsistent state for the LVGs.

This commit fixes the issue described above. It detects this specific abnormal scenario and handles it by transforming the state to: `lvg1 (localvolume: pvcB, pvc: lvA)` and `lvg2 (localvolume: "", pvc: "")`, thereby restoring the LVG state to consistency.

In summary, the PVC/PV mechanism in K8s is very flexible and powerful. The initial design of the LVG might not have accounted for all such edge use cases, which can make fixing these issues feel quite challenging. Furthermore, when using Hwameistor, a lack of deep understanding of the LVG can lead to a lack of confidence. In my view, in the short term, targeted fixes can be applied for specific edge cases like this one. However, in the long term, it's necessary to conduct a comprehensive evaluation of the LVG to consider whether it is robust enough to handle the variety of usage scenarios effectively.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: issues with volume creation and LVG state consistency to improve reliability
```
