### PR TITLE
fix: stop migrate job when configmap is exist

### DIFF
--- a/pkg/local-storage/member/controller/volume_migrate_task_worker.go
+++ b/pkg/local-storage/member/controller/volume_migrate_task_worker.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+
 	apisv1alpha1 "github.com/hwameistor/hwameistor/pkg/apis/hwameistor/v1alpha1"
 	"github.com/hwameistor/hwameistor/pkg/local-storage/utils"
 	"github.com/hwameistor/hwameistor/pkg/local-storage/utils/datacopy"
@@ -440,7 +441,10 @@ func (m *manager) volumeMigrateCleanup(migrate *apisv1alpha1.LocalVolumeMigrate)
 		cm := &corev1.ConfigMap{}
 		if err := m.apiClient.Get(ctx, types.NamespacedName{Namespace: m.namespace, Name: cmName}, cm); err == nil {
 			logCtx.WithField("configmap", cmName).Debug("Cleanup the migrate config")
-			m.apiClient.Delete(ctx, cm)
+			if err = m.apiClient.Delete(ctx, cm); err != nil {
+				logCtx.WithError(err).WithField("configmap", cmName).Debug("Failed to cleanup the migrate config")
+				return err
+			}
 		}
 	}
 	return m.apiClient.Delete(ctx, migrate)


### PR DESCRIPTION
A localvolume may be migrated many times, but the configmap has the same name, this may cause problems when source node and target node are different in two migrations.

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
