### PR TITLE
Correct storage calculation in scheduler after LVM pool deletion

### DIFF
--- a/pkg/local-storage/member/controller/scheduler/resources.go
+++ b/pkg/local-storage/member/controller/scheduler/resources.go
@@ -539,7 +539,15 @@ func (r *resources) updateAllocatedStorageByLSN(node *apisv1alpha1.LocalStorageN
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	for _, pool := range node.Status.Pools {
+	for poolName := range r.allocatedStorages.pools {
+		pool, ok := node.Status.Pools[poolName]
+		if !ok {
+			delete(r.allocatedStorages.pools[poolName].capacities, node.Name)
+			delete(r.allocatedStorages.pools[poolName].volumeCount, node.Name)
+			delete(r.allocatedStorages.pools[poolName].thinPoolCapacities, node.Name)
+			continue
+		}
+
 		r.allocatedStorages.pools[pool.Name].capacities[node.Name] = pool.UsedCapacityBytes
 		r.allocatedStorages.pools[pool.Name].volumeCount[node.Name] = pool.UsedVolumeCount
 		if pool.ThinPool == nil {
@@ -554,10 +562,10 @@ func (r *resources) delAllocatedStorageByLSN(node *apisv1alpha1.LocalStorageNode
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	for _, pool := range node.Status.Pools {
-		delete(r.allocatedStorages.pools[pool.Name].capacities, node.Name)
-		delete(r.allocatedStorages.pools[pool.Name].volumeCount, node.Name)
-		delete(r.allocatedStorages.pools[pool.Name].thinPoolCapacities, node.Name)
+	for poolName := range r.allocatedStorages.pools {
+		delete(r.allocatedStorages.pools[poolName].capacities, node.Name)
+		delete(r.allocatedStorages.pools[poolName].volumeCount, node.Name)
+		delete(r.allocatedStorages.pools[poolName].thinPoolCapacities, node.Name)
 	}
 }
 
@@ -636,7 +644,15 @@ func (r *resources) addTotalStorage(node *apisv1alpha1.LocalStorageNode) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	for _, pool := range node.Status.Pools {
+	for poolName := range r.totalStorages.pools {
+		pool, ok := node.Status.Pools[poolName]
+		if !ok {
+			delete(r.totalStorages.pools[poolName].capacities, node.Name)
+			delete(r.totalStorages.pools[poolName].volumeCount, node.Name)
+			delete(r.totalStorages.pools[poolName].thinPoolCapacities, node.Name)
+			continue
+		}
+
 		r.totalStorages.pools[pool.Name].capacities[node.Name] = pool.TotalCapacityBytes
 		r.totalStorages.pools[pool.Name].volumeCount[node.Name] = pool.TotalVolumeCount
 		if pool.ThinPool == nil {
@@ -653,10 +669,10 @@ func (r *resources) delTotalStorage(node *apisv1alpha1.LocalStorageNode) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	for _, pool := range node.Status.Pools {
-		delete(r.totalStorages.pools[pool.Name].capacities, node.Name)
-		delete(r.totalStorages.pools[pool.Name].volumeCount, node.Name)
-		delete(r.totalStorages.pools[pool.Name].thinPoolCapacities, node.Name)
+	for poolName := range r.totalStorages.pools {
+		delete(r.totalStorages.pools[poolName].capacities, node.Name)
+		delete(r.totalStorages.pools[poolName].volumeCount, node.Name)
+		delete(r.totalStorages.pools[poolName].thinPoolCapacities, node.Name)
 	}
 	delete(r.storageNodes, node.Name)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

Users may delete an lvm storage pool manually, and the pool status in `lsn.status.pools[POOL_NAME]` will be nil.

Currently, resource state in scheduler is from lsn, but it doesn't take pool deletion into consideration.

This PR corrects the handling of `allocatedStorages` and `totalStorages` in the scheduler to account for this scenario.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: correct storage calculation in scheduler after LVM pool deletion
```
