### PR TITLE
docs: fix README typos and wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ HwameiStor contains several modules:
 * [HA module installer](#ha-module-installer)
 * [Volume Snapshot](#volume-snapshot)
 * [Volume Auto Resize](#volume-auto-resize)
-* [Volume IO Throttling](#volume-io-throtting)
+* [Volume IO Throttling](#volume-io-throttling)
 * [App Failover](#app-failover)
 * [Audit](#audit)
 * [UI](#ui)
@@ -198,7 +198,7 @@ For i18n/cn, you can change the nav in `current.json`:
 | LVM Volume migration      | Completed | v0.4.0  | Migrate a LVM volume replica to a different node                                |
 | Volume Group              | Completed | v0.3.2  | Support volume group allocation                                                 |
 | Disk health check         | Completed | v0.7.0  | Disk fault prediction, status reporting                                         |
-| LVM HA Volume Recovery    | Planned   |         | Recover the LVM HA volume in problem                                            |
+| LVM HA Volume Recovery    | Planned   |         | Recover the LVM HA volume when problems occur                                            |
 | HwameiStor Operator       | Completed | v0.9.0  | Operator for HwameiStor install, maintain, etc.                                 |
 | Observability             | Completed | v0.9.2  | Observability, such as metrics, logs, etc.                                      |
 | Failover                  | Completed | v0.12.0 | Fail over the pod with HwameiStor volume                                        |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ HwameiStor contains several modules:
 * [HA module installer](#ha-module-installer)
 * [Volume Snapshot](#volume-snapshot)
 * [Volume Auto Resize](#volume-auto-resize)
-* [Volume IO Throtting](#volume-io-throtting)
+* [Volume IO Throttling](#volume-io-throtting)
 * [App Failover](#app-failover)
 * [Audit](#audit)
 * [UI](#ui)
@@ -112,19 +112,19 @@ Currently, the snapshot/restore feature works for LVM non-HA volume.
 
 ### Volume Auto Resize
 
-HwameiStor can automatically expand the LVM volume according the pre-defined resize policy.
+HwameiStor can automatically expand the LVM volume according to the pre-defined resize policy.
 User can define the preferred policy and describe how and when to expand the volume, and HwameiStor will take the policy into effect.
 [Learn more](docs/docs/volumes/pvc_autoresizing.md)
 
-### Volume IO Throtting
+### Volume IO Throttling
 
-HwameiStor can set a maxmium rate (e.g. bandwidth, IOPS) to access a volume.
+HwameiStor can set a maximum rate (e.g. bandwidth, IOPS) to access a volume.
 This feature is very important to prevent the Pod from crashing, especially in the low-resource condition.
 [Learn more](docs/docs/volumes/volume_provisioned_io.md)
 
 ### App Failover
 
-The feature of failover is to actively help the application to fail over to another health node with the volume replica, and continue the working.
+The feature of failover is to actively help the application to fail over to another health node with the volume replica, and continue working.
 [Learn more](docs/docs/fast_failover.md)
 
 ### Audit


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix a few small but user-visible typos/wording issues in the English README:
- `Volume IO Throtting` -> `Volume IO Throttling`
- `maxmium` -> `maximum`
- `according the` -> `according to`
- `continue the working` -> `continue working`

#### Special notes for your reviewer:

This is a docs-only change with no functional impact.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```