### PR TITLE
docs: polish README roadmap copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,14 @@ For i18n/cn, you can change the nav in `current.json`:
 | LVM volume auto-expansion | Completed | v0.12.0 | Expand LVM volume automatically                                                 |
 | LVM volume snapshot       | Completed | v0.12.0 | Snapshot of LVM volume                                                          |
 | LVM volume clone          | Completed | v0.13.1 | Clone LVM volume                                                                |
-| LVM volume thin provision | Planned  |         | LVM volume thin provision                                                       |
-| LVM volume stripe mode    | Unplanned  |         | LVM volume stripe read/write                                                    |
+| LVM volume thin provision | Planned   |         | LVM volume thin provisioning                                                   |
+| LVM volume stripe mode    | Unplanned |         | LVM volume stripe read/write                                                   |
 | Data encryption           | Completed | v0.16.0 | Data encryption                                                                 |
 | System Consistency        | Planned   |         | Consistent check and recovery from a disaster                                   |
 | Volume backup             | Planned   |         | Backup the volume data to remote server and restore                             |
-| HwameiStor CLI command    | Completed | v0.12.4 | The CLI command is used to manage the HwameiStor cluster                                 |
+| HwameiStor CLI command    | Completed | v0.12.4 | The CLI is used to manage the HwameiStor cluster                               |
 | HwameiStor GUI            | Completed | v0.11.0 | Manage the HwameiStor cluster                                                   |
-| Cache Volume              | Completed | v0.14.5 | Accelerate dataset loading on node                                             |
+| Cache Volume              | Completed | v0.14.5 | Accelerate dataset loading on nodes                                            |
 
 ## Community
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Polish a few small wording/formatting issues in the README roadmap table:
- normalize `Planned` / `Unplanned` spacing for consistent table formatting
- change `thin provision` to `thin provisioning`
- simplify the HwameiStor CLI description
- change `on node` to `on nodes` for clearer wording

#### Special notes for your reviewer:

This is a docs-only change with no functional impact. The PR contains a single DCO-signed commit.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```