### PR TITLE
fix(webhook): apply updated failurePolicy during webhook refresh

### DIFF
--- a/pkg/webhook/config/config.go
+++ b/pkg/webhook/config/config.go
@@ -157,16 +157,7 @@ func CreateAdmissionConfig(caCert *bytes.Buffer) error {
 			}
 		}
 
-		// don't update FailurePolicy and NamespaceSelector if the field is already exist
-		if len(existMutateConfig.Webhooks) > 0 {
-			if existMutateConfig.Webhooks[0].FailurePolicy != nil {
-				updateMutateConfig.Webhooks[0].FailurePolicy = existMutateConfig.Webhooks[0].FailurePolicy
-			}
-			if existMutateConfig.Webhooks[0].NamespaceSelector.MatchExpressions != nil ||
-				existMutateConfig.Webhooks[0].NamespaceSelector.MatchLabels != nil {
-				updateMutateConfig.Webhooks[0].NamespaceSelector = existMutateConfig.Webhooks[0].NamespaceSelector
-			}
-		}
+		mergeExistingWebhookSettings(updateMutateConfig, existMutateConfig)
 
 		updateMutateConfig.ResourceVersion = existMutateConfig.ResourceVersion
 		if _, err = mutateAdmissionClient.Update(ctx, updateMutateConfig, metav1.UpdateOptions{}); err != nil {
@@ -210,6 +201,22 @@ func ensureNameSpaceKeyExist(clientset *k8s.Clientset) error {
 	}
 
 	return nil
+}
+
+func mergeExistingWebhookSettings(updateMutateConfig, existMutateConfig *admissionregistrationv1.MutatingWebhookConfiguration) {
+	if updateMutateConfig == nil || existMutateConfig == nil {
+		return
+	}
+	if len(updateMutateConfig.Webhooks) == 0 || len(existMutateConfig.Webhooks) == 0 {
+		return
+	}
+
+	// Preserve any user-customized namespace selector, but allow failurePolicy
+	// to follow the current deployment configuration.
+	existingSelector := existMutateConfig.Webhooks[0].NamespaceSelector
+	if existingSelector != nil && (existingSelector.MatchExpressions != nil || existingSelector.MatchLabels != nil) {
+		updateMutateConfig.Webhooks[0].NamespaceSelector = existingSelector
+	}
 }
 
 func GetFailurePolicy() *admissionregistrationv1.FailurePolicyType {

--- a/pkg/webhook/config/config_test.go
+++ b/pkg/webhook/config/config_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMergeWebhookPreservesNamespaceSelectorButRefreshesFailurePolicy(t *testing.T) {
+	ignore := admissionregistrationv1.Ignore
+	fail := admissionregistrationv1.Fail
+
+	update := &admissionregistrationv1.MutatingWebhookConfiguration{
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
+			FailurePolicy: &ignore,
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "hwameistor.io/webhook",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"ignore"},
+				}},
+			},
+		}},
+	}
+
+	existing := &admissionregistrationv1.MutatingWebhookConfiguration{
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
+			FailurePolicy: &fail,
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"custom": "selector"},
+			},
+		}},
+	}
+
+	mergeExistingWebhookSettings(update, existing)
+
+	if update.Webhooks[0].FailurePolicy == nil || *update.Webhooks[0].FailurePolicy != ignore {
+		t.Fatalf("expected failure policy to remain %q, got %#v", ignore, update.Webhooks[0].FailurePolicy)
+	}
+
+	if got := update.Webhooks[0].NamespaceSelector; got == nil || got.MatchLabels["custom"] != "selector" {
+		t.Fatalf("expected namespace selector to be preserved, got %#v", got)
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix a real behavior bug around admission webhook updates.

Today, `CreateAdmissionConfig` preserves both the existing `NamespaceSelector` and the existing `FailurePolicy` when a `MutatingWebhookConfiguration` already exists. That means a later config change (for example, switching from `Ignore` to `Fail` via the operator/Helm flow) never propagates to the webhook object.

This PR keeps preserving a customized `NamespaceSelector`, but allows `FailurePolicy` to follow the current configuration.

It also adds a focused unit test that reproduces the bug and verifies the fix.

Related context: hwameistor/hwameistor-operator#311

#### Special notes for your reviewer:

Validation performed:
- `go test ./pkg/webhook/config`
- `go test ./pkg/webhook/...`

#### Does this PR introduce a user-facing change?
```release-note
Fixes an issue where updated admission webhook failurePolicy settings could be ignored during webhook configuration refreshes.
```