### PR TITLE
fix(apiserver): avoid panic on empty local disk device path

### DIFF
--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller.go
@@ -44,6 +44,13 @@ func NewLocalStorageNodeController(client client.Client, clientset *kubernetes.C
 func (lsnController *LocalStorageNodeController) SetLdHandler(handler *localdisk.Handler) {
 	lsnController.ldHandler = handler
 }
+
+func deviceShortName(devicePath string) string {
+	if devicePath == "" {
+		return ""
+	}
+	return strings.TrimPrefix(devicePath, hwameistorapi.DEV)
+}
 func (lsnController *LocalStorageNodeController) GetLocalStorageNode(key client.ObjectKey) (*apisv1alpha1.LocalStorageNode, error) {
 	lsn := &apisv1alpha1.LocalStorageNode{}
 	if err := lsnController.Client.Get(context.TODO(), key, lsn); err != nil {
@@ -401,8 +408,7 @@ func (lsnController *LocalStorageNodeController) ListStorageNodeDisks(queryPage 
 		disk.TotalCapacityBytes = diskList.Items[i].Spec.Capacity
 		availableCapacityBytes := lsnController.getAvailableDiskCapacity(queryPage.NodeName, diskList.Items[i].Spec.DevicePath, diskList.Items[i].Spec.DiskAttributes.Type)
 		disk.AvailableCapacityBytes = availableCapacityBytes
-		diskShortName := strings.Split(diskList.Items[i].Spec.DevicePath, hwameistorapi.DEV)[1]
-		disk.DiskPathShort = diskShortName
+		disk.DiskPathShort = deviceShortName(diskList.Items[i].Spec.DevicePath)
 
 		log.Infof("ListStorageNodeDisks queryPage.DiskState = %v", queryPage.DiskState)
 		if queryPage.DiskState == "" || (queryPage.DiskState != "" && queryPage.DiskState == disk.Status.State) {
@@ -533,8 +539,7 @@ func (lsnController *LocalStorageNodeController) GetStorageNodeDisk(page hwameis
 	}
 	ldi.LocalDisk = localDisks[0]
 	ldi.TotalCapacityBytes = localDisks[0].Spec.Capacity
-	diskShortName := strings.Split(localDisks[0].Spec.DevicePath, hwameistorapi.DEV)[1]
-	ldi.DiskPathShort = diskShortName
+	ldi.DiskPathShort = deviceShortName(localDisks[0].Spec.DevicePath)
 	if localDisks[0].Spec.DiskAttributes.Type == hwameistorapi.DiskClassNameHDD {
 		ldi.LocalStoragePooLName = hwameistorapi.PoolNameForHDD
 	} else if localDisks[0].Spec.DiskAttributes.Type == hwameistorapi.DiskClassNameSSD {

--- a/pkg/apiserver/manager/hwameistor/localstoragenode_controller_test.go
+++ b/pkg/apiserver/manager/hwameistor/localstoragenode_controller_test.go
@@ -1,0 +1,23 @@
+package hwameistor
+
+import "testing"
+
+func TestDeviceShortName(t *testing.T) {
+	tests := []struct {
+		name       string
+		devicePath string
+		want       string
+	}{
+		{name: "regular dev path", devicePath: "/dev/sdb", want: "sdb"},
+		{name: "empty path", devicePath: "", want: ""},
+		{name: "already short", devicePath: "sdb", want: "sdb"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deviceShortName(tt.devicePath); got != tt.want {
+				t.Fatalf("deviceShortName(%q) = %q, want %q", tt.devicePath, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix a localized panic in the apiserver storage-node disk handlers.

The code derived `DiskPathShort` with `strings.Split(devicePath, "/dev/")[1]`. That panics when `DevicePath` is empty or does not contain the expected prefix. This is a real edge case because inactive/stale `LocalDisk` objects can have their `DevicePath` cleared.

This PR switches the two call sites to a small safe helper and adds a focused unit test.

#### Special notes for your reviewer:

Validation:
- `go test -vet=off ./pkg/apiserver/manager/hwameistor/...`

Note: running the same package tests without `-vet=off` is currently blocked by a pre-existing unrelated `go vet` warning in this package (`log.Error` used with a formatting directive). This PR does not touch that line.

#### Does this PR introduce a user-facing change?
```release-note
Fixes a panic in the apiserver when listing or reading storage-node disks whose LocalDisk device path is empty.
```