### PR TITLE
Implement the Possibility to add ExtraEnvs to local-storage container to set PATH for Nixos

### DIFF
--- a/helm/hwameistor/templates/local-storage.yaml
+++ b/helm/hwameistor/templates/local-storage.yaml
@@ -98,6 +98,9 @@ spec:
           value: localstorage.hwameistor.io/storage-ipv4
         - name: MIGRAGE_JUICESYNC_IMAGE
           value: {{ .Values.global.hwameistorImageRegistry }}/{{ .Values.localStorage.migrate.juicesync.imageRepository }}:{{ .Values.localStorage.migrate.juicesync.tag }}
+        {{- with .Values.localStorage.member.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: {{ .Values.global.hwameistorImageRegistry }}/{{ .Values.localStorage.member.imageRepository }}:{{ template "hwameistor.localstorageImageTag" . }}
         imagePullPolicy: IfNotPresent
         name: member

--- a/helm/hwameistor/values.yaml
+++ b/helm/hwameistor/values.yaml
@@ -137,6 +137,7 @@ localStorage:
     imageRepository: hwameistor/local-storage
     tag: ""
     resources: {}
+    extraEnv: []
   migrate:
     juicesync:
       imageRepository: hwameistor/hwameistor-juicesync


### PR DESCRIPTION
… 

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
When deploying hwameistor on a node that does not have the (e.g. vgs) binaries on the standard linux path like NixOS, the container fails to operate. By introducing the **extraEnv** flag we can add a PATH env where the path to the binaries is set.

#### Does this PR introduce a user-facing change?
Not really. Nothing changes if not specifically set.

```release-note
NONE
```
