### PR TITLE
ci: enable workflows on release/v1.1 branch

### DIFF
--- a/.github/workflows/Cherry-picking.yml
+++ b/.github/workflows/Cherry-picking.yml
@@ -31,4 +31,23 @@ jobs:
             cherry-pick
 #          reviewers: |
 #            aReviewerUser
-
+  cherry_pick_release_v1_1:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Allows the GITHUB_TOKEN to write to the repository
+      pull-requests: write
+    name: Cherry pick into release-v1.1
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'cherry-pick-v1.1') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into release-v1.1
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        with:
+          branch: release/v1.1
+          labels: |
+            cherry-pick
+#          reviewers: |
+#            aReviewerUser

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - release/v1.0.0
+      - release/v1.1
     paths:
       - "pkg/**"
       - "cmd/**"

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release/v1.0.0
+      - release/v1.1
     paths:
       - "helm/hwameistor/Chart.yaml"
 


### PR DESCRIPTION
Add release/v1.1 to the branch triggers of the PR CI (pr.yml) and the helm chart release workflow (release-chart.yaml), and add a parallel cherry-pick job in Cherry-picking.yml that targets release/v1.1 (fires on the 'cherry-pick-v1.1' label).

This unblocks CI for the v1.1.x line, which is the maintenance branch that will carry the scheduler upgrade needed to fix #1848. The existing release/v1.0.0 configuration is preserved and untouched.

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
