### PR TITLE
ci: bump builder image Go to 1.24.13 (prerequisite for #1851)

### DIFF
--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.11-alpine
+FROM golang:1.24.13-alpine
 
 # set mirror repository for the package management
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/' /etc/apk/repositories


### PR DESCRIPTION
Split out from #1851 to break the chicken-and-egg cycle:

1. Merge this PR (its own pr-test passes — old builder can still build the current go 1.21 go.mod)
2. Dispatch **Release Builder** workflow from `release/v1.1` to rebuild `hwameistor-builder:latest` with go1.24.13
3. Rerun pr-test on #1851 — it should then pass and #1851 can merge green

Go 1.24.13 also fixes CVE-2025-68121 (crypto/tls incorrect certificate validation during TLS session resumption) in the stdlib compiled into all release binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)