### PR TITLE
ci: cve-scan covers all 11 module images via the official make image path

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -4,6 +4,7 @@ name: CVE Scan
 # 避免打 tag 之后才在 release-image job 失败:
 # 1. PR 改到依赖/构建文件时扫描
 # 2. 每周定时扫描 (CVE 随漏洞库更新新增, 代码不变也可能超标)
+# 3. 打 tag 前手动 dispatch 做发布预检
 on:
   pull_request:
     branches:
@@ -21,14 +22,13 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  cve-scan:
+  # ---- 第 1 层: 源码依赖扫描 (秒级, 捕获 go.mod 依赖 CVE) ----
+  # v1.1.0 失败的 grpc CVE-2026-33186 属于此类, 在这里即可拦截
+  deps-scan:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      # ---- 第 1 层: 源码依赖扫描 (秒级, 捕获 go.mod 依赖 CVE) ----
-      # v1.1.0 失败的 grpc CVE-2026-33186 属于此类, 在这里即可拦截
       - name: Trivy scan go dependencies
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -38,53 +38,49 @@ jobs:
           severity: CRITICAL
           exit-code: "1"
           ignore-unfixed: true
-          # docs 站点的 npm 依赖不进发布产物, release 门禁也不扫它们;
-          # 如需治理另行处理, 不阻塞发布门禁镜像检查
+          # docs 站点的 npm 依赖不进发布产物, release 门禁也不扫它们
           skip-files: package-lock.json,docs/package-lock.json
 
-      # ---- 第 2 层: 真实二进制扫描 (捕获 Go stdlib/工具链 CVE) ----
-      # v1.1.0 失败的 crypto/tls CVE-2025-68121 编进二进制的 stdlib 版本决定,
-      # 必须用与 release 相同的工具链编译出二进制才能验证.
-      # 注意: 不用 make ldm_image, 因为它依赖 ghcr 上的 builder:latest 镜像,
-      # builder 镜像的 Go 版本可能滞后于 build/builder/Dockerfile 的改动.
-      - name: Setup go (from go.mod toolchain)
-        uses: actions/setup-go@v5
+  # ---- 第 2 层: 全量镜像扫描 (与 release 产物/门禁完全一致) ----
+  # 用官方构建路径 `make image` 构建全部 11 个模块镜像 (buildx -o type=docker
+  # 只落 CI runner 本地 daemon, 无 push 步骤, 不会发布任何产物),
+  # 再对每个镜像执行与 scan-image-with-trivy.sh 相同的门禁.
+  # 覆盖: builder 工具链编译进二进制的 stdlib CVE (如 crypto/tls
+  # CVE-2025-68121) + 基础镜像 OS 层 + 各 Dockerfile yum install 的包.
+  image-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          go-version-file: go.mod
-      - name: Build release binaries
+          fetch-depth: 0
+      - name: Set env
         run: |
-          mkdir -p _build
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-            go build -o _build/local-disk-manager ./cmd/local-disk-manager
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-            go build -o _build/local-storage ./cmd/local-storage
-      - name: Trivy scan binaries (same gate as release)
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          scan-type: rootfs
-          scan-ref: _build
-          scanners: vuln
-          severity: CRITICAL
-          exit-code: "1"
-        env:
-          # 复用第 1 步下载的漏洞库
-          TRIVY_SKIP_DB_UPDATE: "true"
-
-      # ---- 第 3 层: 真实发布镜像扫描 (与 release 门禁完全一致) ----
-      # 用仓库真实的 Dockerfile 构建镜像再扫, 覆盖基础镜像 OS 层 +
-      # RUN yum install 装入的包 + 二进制, 三者合一.
-      # (只扫裸 rockylinux:8 会漏掉 yum install 引入的包的 CVE)
-      - name: Build local-disk-manager image (same Dockerfile as release)
+          echo "PROJECT_SOURCE_CODE_DIR=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+          echo "IMAGE_REGISTRY=ghcr.io/$(echo ${{ github.repository_owner }} | tr 'A-Z' 'a-z')" >> $GITHUB_ENV
+          echo "IMAGE_TAG=cve-scan-local" >> $GITHUB_ENV
+      - name: Build all module images locally (no push)
         run: |
-          docker build -t cve-scan/local-disk-manager:pr \
-            -f build/local-disk-manager/Dockerfile .
-      - name: Trivy scan release image (same gate as release)
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          scan-type: image
-          image-ref: cve-scan/local-disk-manager:pr
-          scanners: vuln
-          severity: CRITICAL
-          exit-code: "1"
-        env:
-          TRIVY_SKIP_DB_UPDATE: "true"
+          # make image 通过 builder 镜像编译 + buildx 构建到本地 daemon,
+          # 与 release_xxx 的 amd64 构建路径一致, 但没有 push 步骤
+          make image
+      - name: Install trivy
+        run: |
+          which trivy || curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin latest
+      - name: Scan all images with release gate (CRITICAL, exit-code 1)
+        run: |
+          MODULES="local-disk-manager local-storage scheduler admission \
+                   evictor exporter apiserver failover-assistant auditor \
+                   pvc-autoresizer local-disk-action-controller"
+          failed=""
+          for m in ${MODULES}; do
+            echo "# scanning ${IMAGE_REGISTRY}/${m}:${IMAGE_TAG} ..."
+            trivy image ${IMAGE_REGISTRY}/${m}:${IMAGE_TAG} \
+              --severity CRITICAL --exit-code 1 --skip-version-check \
+              || failed="${failed} ${m}"
+          done
+          if [ -n "${failed}" ]; then
+            echo "[Error] CRITICAL vulnerabilities found in:${failed}"
+            exit 1
+          fi
+          echo "# all module images passed the CRITICAL gate"


### PR DESCRIPTION
Improves the cve-scan workflow added in #1851:

## What changed

The image layer now uses `make image` — the official build path (builder-container compile + buildx `-o type=docker`) — to build **all 11 module images into the CI runner's local daemon only** (the `build_xxx_image` targets contain no push step, so nothing can leak), then applies the exact release gate (`trivy --severity CRITICAL --exit-code 1`) to each image.

## Gaps closed vs the previous version

1. **Coverage**: previously only `local-disk-manager` was built and scanned; other modules' Dockerfiles install different yum packages (e.g. local-storage adds cryptsetup) that were unscanned.
2. **Toolchain fidelity**: previously binaries were compiled with `setup-go`; now they are compiled inside `hwameistor-builder:latest`, identical to the real release, so stdlib CVE detection matches exactly what release would ship.

## Verification path

This PR itself triggers the workflow (paths include the yml), so the run on this PR demonstrates the full 11-image build+scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)