### PR TITLE
Release v1.1.1

### DIFF
--- a/helm/hwameistor/Chart.yaml
+++ b/helm/hwameistor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hwameistor
 description: the HwameiStor local storage
 type: application
-version: v1.1.0
-appVersion: v1.1.0
+version: v1.1.1
+appVersion: v1.1.1
 icon: https://hwameistor.io/img/logo.svg
 kubeVersion: ">=1.26.0-0"


### PR DESCRIPTION
Bump `helm/hwameistor/Chart.yaml` to **v1.1.1** (version + appVersion).

## Why v1.1.1

v1.1.0's release-image job failed at the trivy CRITICAL gate and its images were never pushed ([failed run](https://github.com/hwameistor/hwameistor/actions/runs/28771088365)). The CVEs are fixed on this branch by #1851 (grpc v1.79.3, Go 1.24.13) with builder prerequisite #1852. A full 11-image build + release-gate scan dry-run passed: [cve-scan run](https://github.com/hwameistor/hwameistor/actions/runs/29888511297).

## What merging this triggers

`release-chart.yaml` fires on Chart.yaml changes pushed to `release/v1.1`:
1. chart-releaser: tags **v1.1.1**, creates the GitHub Release, uploads chart tgz, updates gh-pages index
2. hwameictl binaries build and attach to the release
3. release-image: builds all module images, trivy-scans (gate), pushes to ghcr with tag v1.1.1

Empty `tag: ""` entries in values.yaml are rendered to the chart version by `render-chart-values.sh` during the workflow, so the chart will reference the v1.1.1 images.

Post-release cleanup (separate): remove the never-published v1.1.0 release/tag and its gh-pages index entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)